### PR TITLE
[UPD] ssi_letter - IK & tour untuk 5 model

### DIFF
--- a/.github/workflows/docstring-gate.yml
+++ b/.github/workflows/docstring-gate.yml
@@ -1,0 +1,284 @@
+# Gerbang docstring — memerahkan PR yang MENAMBAH class/method tanpa docstring.
+#
+# Aturannya milik skill `odoo-development`,
+# references/odoo-module-guidelines/10-docstring.md; berkas ini hanya menegakkannya
+# di CI. Salinan mekanis yang sama ada di `assets/verify-module.sh` skill itu — bila
+# salah satu diubah, ubah keduanya (kontrak validator §13 memakai kunci temuan yang
+# sama persis, jadi baris `.validator-exceptions` berlaku di dua-duanya).
+#
+# ── KENAPA WORKFLOW TERSENDIRI, BUKAN HOOK pre-commit ────────────────────────
+# `pre-commit run --all-files` di CI berjalan saat pohon kerja SAMA DENGAN HEAD, jadi
+# pembanding "apa yang baru" tidak ada dan hook seperti ini selalu hijau di sana —
+# hijau palsu. Workflow ini membandingkan HEAD PR dengan `merge-base` branch tujuan,
+# yang memang pembanding yang benar untuk "apa yang PR ini perkenalkan".
+#
+# ── KENAPA HANYA PELANGGARAN BARU ────────────────────────────────────────────
+# Korpus 14.0 memuat ~12.400 class/method tanpa docstring di 77 repo (sapuan 2026-08).
+# Memerahkan semuanya sekaligus tidak membuat satu docstring pun tertulis; ia hanya
+# membuat gerbang ini dimatikan. Yang ditahan karena itu HANYA simbol yang tak
+# berdocstring DAN belum ada di merge-base. Utang warisan diukur terpisah lewat
+# `audit-sweep.sh` (skill odoo-development-repo-ops), bukan di sini.
+#
+# Berkas ini identik di semua repo modul SSI dan semua seri Odoo — tanpa placeholder,
+# tanpa filter branch, supaya sync-config.sh bisa memverifikasinya byte-per-byte.
+name: docstring gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docstring-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docstring-gate:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Wajib: merge-base tidak bisa dihitung dari checkout dangkal.
+          fetch-depth: 0
+      - name: Gerbang docstring (hanya pelanggaran baru)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$BASE_REF"
+          MERGE_BASE="$(git merge-base "origin/$BASE_REF" HEAD)"
+          echo "Pembanding : origin/$BASE_REF @ $MERGE_BASE"
+          echo
+          python3 - "$MERGE_BASE" <<'PY'
+          import ast
+          import os
+          import subprocess
+          import sys
+
+          MERGE_BASE = sys.argv[1]
+          RULE = "setiap-class-method-punya-docstring"
+
+
+          def git(*args):
+              """Keluaran sebuah perintah git, atau None bila perintahnya gagal."""
+              proc = subprocess.run(
+                  ["git"] + list(args), capture_output=True, text=True
+              )
+              return proc.stdout if proc.returncode == 0 else None
+
+
+          # --- aturan pengecualian (CERMIN verify-module.sh; 10-docstring.md) ------
+          EXEMPT_EXACT = {"_insert_form_element", "_get_policy_field"}
+          ONCHANGE_PREFIX = ("onchange_", "_onchange_")
+
+
+          def real_body(fn):
+              """Statement body sebuah fungsi, tanpa baris docstring-nya."""
+              return fn.body[1:] if ast.get_docstring(fn) is not None else fn.body
+
+
+          def is_simple_onchange(fn):
+              """True bila onchange-nya Pattern A/B/C — reset/set field, titik.
+
+              decorator_list sengaja tidak ditelusuri: `@api.onchange("x")` sendiri
+              sebuah ``ast.Call``, dan menelusurinya membuat SETIAP onchange
+              terhitung tidak sederhana.
+              """
+              for st in real_body(fn):
+                  if not isinstance(st, (ast.Assign, ast.If)):
+                      return False
+                  for node in ast.walk(st):
+                      if isinstance(
+                          node,
+                          (
+                              ast.Call,
+                              ast.For,
+                              ast.While,
+                              ast.Try,
+                              ast.With,
+                              ast.Return,
+                              ast.Lambda,
+                          ),
+                      ):
+                          return False
+              return True
+
+
+          def doc_exempt(fn):
+              """True bila fungsi ini masuk pengecualian TERTUTUP 10-docstring.md."""
+              if fn.name in EXEMPT_EXACT:
+                  return True
+              if fn.name.startswith(ONCHANGE_PREFIX):
+                  return is_simple_onchange(fn)
+              if fn.name.startswith("_selection_"):
+                  return len(real_body(fn)) <= 1
+              return False
+
+
+          def missing_symbols(source):
+              """{nama simbol: lineno} untuk class/method tanpa docstring.
+
+              None bila sumbernya gagal di-parse — berkas yang sintaksnya rusak
+              ditagih flake8/pylint, dan menebak isinya di sini hanya menghasilkan
+              temuan palsu.
+              """
+              try:
+                  tree = ast.parse(source)
+              except SyntaxError:
+                  return None
+              found = {}
+              for node in ast.walk(tree):
+                  if not isinstance(
+                      node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+                  ):
+                      continue
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                      if doc_exempt(node):
+                          continue
+                  if ast.get_docstring(node) is None:
+                      found.setdefault(node.name, node.lineno)
+              return found
+
+
+          def module_root(path):
+              """Direktori modul Odoo terdekat di atas `path`, atau None."""
+              cur = os.path.dirname(path)
+              while cur:
+                  if os.path.isfile(os.path.join(cur, "__manifest__.py")):
+                      return cur
+                  parent = os.path.dirname(cur)
+                  if parent == cur:
+                      break
+                  cur = parent
+              return None
+
+
+          _baseline_cache = {}
+
+
+          def module_baseline(module):
+              """Nama simbol tanpa docstring di SELURUH modul, pada merge-base.
+
+              Pembandingnya sengaja setingkat MODUL, bukan per berkas. Standar SSI
+              mengizinkan struktur berkas ditata ulang selama XML ID & nama class utuh
+              (02-core-principles.md), dan perbandingan per berkas membaca pemindahan
+              class warisan sebagai "simbol baru" — lalu menuntut docstring untuk kode
+              yang tidak disentuh PR itu. Deteksi rename bawaan git tidak menutup
+              lubangnya: berkas yang dipindah SEKALIGUS diubah isinya jatuh di bawah
+              ambang kemiripan dan terbaca sebagai hapus + tambah.
+              """
+              if module not in _baseline_cache:
+                  names = set()
+                  listing = git("ls-tree", "-r", "--name-only", MERGE_BASE, "--", module)
+                  for path in (listing or "").splitlines():
+                      if not path.endswith(".py"):
+                          continue
+                      if os.path.basename(path) == "__init__.py":
+                          continue
+                      old_src = git("show", "%s:%s" % (MERGE_BASE, path))
+                      if not old_src:
+                          continue
+                      found = missing_symbols(old_src)
+                      if found:
+                          names.update(found)
+                  _baseline_cache[module] = names
+              return _baseline_cache[module]
+
+
+          _exc_cache = {}
+
+
+          def excepted(module, key):
+              """True bila kunci temuan ini tercakup <modul>/.validator-exceptions."""
+              if module not in _exc_cache:
+                  keys = set()
+                  path = os.path.join(module, ".validator-exceptions")
+                  if os.path.isfile(path):
+                      with open(path, encoding="utf-8") as fh:
+                          for raw in fh:
+                              line = raw.strip()
+                              if not line or line.startswith("#"):
+                                  continue
+                              head, sep, reason = line.partition(" -- ")
+                              if not sep or not reason.strip():
+                                  continue
+                              parts = head.split(None, 1)
+                              if len(parts) == 2 and parts[0] == "module":
+                                  keys.add(parts[1].strip())
+                  _exc_cache[module] = keys
+              return key in _exc_cache[module]
+
+
+          # --- berkas .py yang disentuh PR ini -------------------------------------
+          status = git("diff", "--name-status", "-M", MERGE_BASE, "HEAD")
+          if status is None:
+              sys.exit("ERROR: `git diff` terhadap merge-base gagal.")
+
+          pairs = []  # (path_baru, path_lama|None)
+          for line in status.splitlines():
+              cols = line.split("\t")
+              code = cols[0]
+              if code.startswith("D"):
+                  continue
+              if code.startswith("R") and len(cols) == 3:
+                  pairs.append((cols[2], cols[1]))
+              elif len(cols) >= 2:
+                  pairs.append((cols[1], cols[1]))
+
+          findings = []
+          checked = 0
+          for new_path, old_path in pairs:
+              if not new_path.endswith(".py"):
+                  continue
+              if os.path.basename(new_path) == "__init__.py":
+                  continue
+              # setup/ hanya berisi symlink hasil setuptools-odoo.
+              if new_path.startswith("setup/"):
+                  continue
+              if not os.path.isfile(new_path):
+                  continue
+              with open(new_path, encoding="utf-8") as fh:
+                  new_missing = missing_symbols(fh.read())
+              if new_missing is None:
+                  continue
+              checked += 1
+              module = module_root(new_path)
+              if module:
+                  baseline = module_baseline(module)
+              else:
+                  # Di luar modul Odoo (skrip lepas): tak ada modul untuk dibandingkan,
+                  # jadi pembandingnya kembali ke berkas itu sendiri di merge-base.
+                  old_src = git("show", "%s:%s" % (MERGE_BASE, old_path)) if old_path else None
+                  baseline = set(missing_symbols(old_src) or {}) if old_src else set()
+              for name, lineno in sorted(new_missing.items(), key=lambda kv: kv[1]):
+                  if name in baseline:
+                      continue  # utang warisan — diukur audit-sweep.sh, bukan di sini
+                  rel = os.path.relpath(new_path, module) if module else new_path
+                  if module and excepted(module, "%s|%s %s" % (RULE, rel, name)):
+                      print("  ⊘ %s:%d %s  [.validator-exceptions]" % (new_path, lineno, name))
+                      continue
+                  findings.append((new_path, lineno, name))
+
+          print("Berkas .py diperiksa: %d" % checked)
+          if not findings:
+              print("")
+              print("LOLOS: tidak ada class/method baru tanpa docstring.")
+              sys.exit(0)
+
+          print("")
+          print("GAGAL: %d class/method BARU tanpa docstring." % len(findings))
+          print("")
+          for path, lineno, name in findings:
+              print("  ✗ %s:%d %s" % (path, lineno, name))
+          print("")
+          print("Aturannya: skill odoo-development,")
+          print("  references/odoo-module-guidelines/10-docstring.md")
+          print("Reproduksi & perbaiki di lokal:")
+          print("  assets/vs-head.sh verify-module.sh <path-modul>")
+          print("")
+          print("Pengecualiannya TERTUTUP. Bila sebuah temuan memang tidak boleh")
+          print("diperbaiki, daftarkan di <modul>/.validator-exceptions berikut")
+          print("alasannya (kontrak validator §13) — jangan matikan gerbang ini.")
+          sys.exit(1)
+          PY

--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -1,3 +1,30 @@
+# Caller tipis untuk reusable workflow `andhit-r/notify-telegram`.
+#
+# Seluruh logika notifikasi ada di hulu; berkas ini sengaja tidak memuat apa pun selain
+# trigger + pemanggilan, supaya perbaikan di hulu menyebar tanpa menyentuh repo modul.
+# JANGAN menyalin kembali logika inline ke sini — itu persis kebiasaan yang membuat satu
+# bug ikut tersalin ke 130 repo: Telegram menolak pesan lebih dari 4096 karakter dengan
+# `400 message is too long`, sehingga seluruh run CI jadi merah.
+#
+# Nilai branch di bawah diisi apply-ssi-overrides.sh sesuai versi repo (14.0, 19.0, …).
+# Placeholder-nya sengaja TIDAK disebut di komentar mana pun: substitusinya `sed` polos,
+# jadi penyebutan di komentar ikut tertimpa dan kalimatnya berubah jadi tak bermakna.
+#
+# Repo hulu bersifat PUBLIK, jadi repo di org mana pun — termasuk `open-synergy` — boleh
+# MEMANGGIL-nya; reusable workflow privat hanya bisa dipanggil repo milik owner yang sama.
+#
+# TAPI IZIN MEMANGGIL DAN PEWARISAN SECRET ADALAH DUA ATURAN BERBEDA. `secrets: inherit`
+# hanya bekerja bila pemanggil dan reusable workflow berada di organisasi/enterprise yang
+# SAMA. Repo `open-synergy/*` memanggil workflow milik user `andhit-r` — beda owner —
+# sehingga `inherit` TIDAK meneruskan secret org dan seluruh run gagal SEBELUM job jalan:
+#   Error when evaluating 'secrets'. ...
+#   Secret TELEGRAM_CODE_BOT_TOKEN is required, but not provided while calling.
+# Karena itu kedua secret DITERUSKAN EKSPLISIT di bawah: ekspresi `${{ secrets.* }}`
+# dievaluasi di konteks pemanggil, jadi secret level repo MAUPUN level org sama-sama
+# terbaca, lintas owner sekalipun. JANGAN kembalikan ke `secrets: inherit`.
+#
+# Secret yang wajib tersedia bagi repo modul (level repo ATAU level org):
+# TELEGRAM_CODE_BOT_TOKEN, TELEGRAM_CHAT_ID.
 name: Notify Telegram on Push
 
 on:
@@ -7,89 +34,7 @@ on:
 
 jobs:
   notify:
-    name: Send Telegram Notification
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build and send Telegram message
-        # Semua data dinamis dilewatkan lewat env (di-set GitHub dengan aman),
-        # BUKAN ditanam ke skrip shell. Mencegah error sintaks & script injection
-        # bila pesan commit mengandung ' ` $() < > & atau karakter khusus lain.
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_CODE_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          REPO: ${{ github.repository }}
-          BRANCH: ${{ github.ref_name }}
-          PUSHER: ${{ github.actor }}
-          COMPARE_URL: ${{ github.event.compare }}
-          COMMITS_JSON: ${{ toJson(github.event.commits) }}
-        # Heredoc ber-quote <<'PYEOF': bash TIDAK menginterpolasi isi Python.
-        run: |
-          python3 <<'PYEOF'
-          import os, json, html, urllib.request, urllib.parse, urllib.error
-
-          repo    = os.environ["REPO"]
-          branch  = os.environ["BRANCH"]
-          pusher  = os.environ["PUSHER"]
-          compare = os.environ["COMPARE_URL"]
-          commits = json.loads(os.environ.get("COMMITS_JSON") or "[]")
-
-          # Telegram HTML hanya kenal &lt; &gt; &amp;; jangan escape kutip
-          # (entity numerik apostrof ditolak parser).
-          def esc(s):
-              return html.escape(s, quote=False)
-
-          lines = []
-          for c in commits:
-              sha    = c["id"][:7]
-              msg    = c["message"].strip()
-              author = esc(c["author"]["name"])
-              ts     = c["timestamp"][:16].replace("T", " ")  # YYYY-MM-DD HH:MM
-
-              msg_lines = msg.split("\n")
-              title = esc(msg_lines[0][:80])  # baris pertama, maks 80 karakter
-              body  = [esc(l) for l in msg_lines[1:] if l.strip()]
-
-              entry = f"  <code>{sha}</code> {title}\n    👤 {author}  🕐 {ts}"
-              if body:
-                  entry += "\n" + "\n".join(f"    {l}" for l in body)
-              lines.append(entry)
-
-          count = len(commits)
-          if count == 1:
-              header = f"📝 <b>1 commit baru</b> di <code>{esc(repo)}</code>"
-          else:
-              header = f"📦 <b>{count} commit baru</b> di <code>{esc(repo)}</code>"
-
-          message = (
-              f"{header}\n"
-              f"Branch: <code>{esc(branch)}</code>\n"
-              f"Pusher: @{esc(pusher)}\n\n"
-              + "\n\n".join(lines)
-              + f'\n\n🔗 <a href="{esc(compare)}">Lihat perubahan</a>'
-          )
-
-          data = urllib.parse.urlencode({
-              "chat_id": os.environ["TELEGRAM_CHAT_ID"],
-              "text": message,
-              "parse_mode": "HTML",
-              "disable_web_page_preview": "true",
-          }).encode()
-
-          url = f'https://api.telegram.org/bot{os.environ["TELEGRAM_BOT_TOKEN"]}/sendMessage'
-          try:
-              with urllib.request.urlopen(urllib.request.Request(url, data=data)) as resp:
-                  result = json.load(resp)
-          except urllib.error.HTTPError as e:
-              result = json.load(e)
-
-          print("Telegram response:", json.dumps(result, ensure_ascii=False))
-          if not result.get("ok"):
-              print("::error::Gagal kirim pesan Telegram")
-              raise SystemExit(1)
-          PYEOF
+    uses: andhit-r/notify-telegram/.github/workflows/notify.yml@v1
+    secrets:
+      TELEGRAM_CODE_BOT_TOKEN: ${{ secrets.TELEGRAM_CODE_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,17 @@ jobs:
         env:
           PIP_INDEX_URL: https://pypi.org/simple
           PIP_EXTRA_INDEX_URL: https://${{ secrets.SSI_PYPI_USER }}:${{ secrets.SSI_PYPI_PASSWORD }}@osmium.simetri-sinergi.biz.id/simple/
+      - name: Pre-install chart of accounts
+        # Memasang l10n_generic_coa ke DB test SEBELUM `oca_init_test_database`.
+        # Saat modul ini berstatus `to install`, pemeriksaan `to_install_l10n`
+        # (account/__init__.py) bernilai benar sehingga `_auto_install_l10n`
+        # berhenti tanpa memasang l10n_us; chart of accounts juga sudah termuat
+        # sebelum demo modul SSI lahir, sehingga `chart_template._load()` tidak
+        # pernah menghapus account.journal/account.account yang dirujuk demo.
+        # Demo TIDAK dimatikan: tour dan skenario uji bergantung padanya.
+        run: |
+          oca_wait_for_postgres
+          odoo -d "$PGDATABASE" -i l10n_generic_coa --http-interface=127.0.0.1 --stop-after-init
       - name: Check licenses
         run: manifestoo -d . check-licenses
         continue-on-error: true

--- a/ssi_letter/README.rst
+++ b/ssi_letter/README.rst
@@ -7,6 +7,52 @@ Letter Management
 =================
 
 
+Work Instruction
+================
+
+* `Create Letter Type <docs/letter_type/index.html>`_
+* `Edit Letter Type <docs/letter_type/index.html>`_
+* `Delete Letter Type <docs/letter_type/index.html>`_
+* `Deactivate Letter Type <docs/letter_type/index.html>`_
+* `Activate Letter Type <docs/letter_type/index.html>`_
+* `Create Internal Memo Type <docs/internal_memo_type/index.html>`_
+* `Edit Internal Memo Type <docs/internal_memo_type/index.html>`_
+* `Delete Internal Memo Type <docs/internal_memo_type/index.html>`_
+* `Deactivate Internal Memo Type <docs/internal_memo_type/index.html>`_
+* `Activate Internal Memo Type <docs/internal_memo_type/index.html>`_
+* `Create Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Edit Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Delete Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Confirm Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Approve Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Reject Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Finish Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Cancel Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Restart Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Reset Document Number — Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Restart Approval Process — Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Create Incoming Letter <docs/incoming_letter/index.html>`_
+* `Edit Incoming Letter <docs/incoming_letter/index.html>`_
+* `Delete Incoming Letter <docs/incoming_letter/index.html>`_
+* `Confirm Incoming Letter <docs/incoming_letter/index.html>`_
+* `Approve Incoming Letter <docs/incoming_letter/index.html>`_
+* `Reject Incoming Letter <docs/incoming_letter/index.html>`_
+* `Cancel Incoming Letter <docs/incoming_letter/index.html>`_
+* `Restart Incoming Letter <docs/incoming_letter/index.html>`_
+* `Reset Document Number — Incoming Letter <docs/incoming_letter/index.html>`_
+* `Restart Approval Process — Incoming Letter <docs/incoming_letter/index.html>`_
+* `Create Internal Memo <docs/internal_memo/index.html>`_
+* `Edit Internal Memo <docs/internal_memo/index.html>`_
+* `Delete Internal Memo <docs/internal_memo/index.html>`_
+* `Confirm Internal Memo <docs/internal_memo/index.html>`_
+* `Approve Internal Memo <docs/internal_memo/index.html>`_
+* `Reject Internal Memo <docs/internal_memo/index.html>`_
+* `Cancel Internal Memo <docs/internal_memo/index.html>`_
+* `Restart Internal Memo <docs/internal_memo/index.html>`_
+* `Reset Document Number — Internal Memo <docs/internal_memo/index.html>`_
+* `Restart Approval Process — Internal Memo <docs/internal_memo/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_letter/__manifest__.py
+++ b/ssi_letter/__manifest__.py
@@ -17,6 +17,7 @@
         "ssi_transaction_open_mixin",
         "ssi_transaction_cancel_mixin",
         "ssi_transaction_partner_mixin",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category/ir_module_category.xml",
@@ -55,6 +56,7 @@
         "views/outgoing_letter_views.xml",
         "views/incoming_letter_views.xml",
         "views/internal_memo.xml",
+        "views/assets.xml",
     ],
     "images": [],
 }

--- a/ssi_letter/docs/incoming_letter/01-create.md
+++ b/ssi_letter/docs/incoming_letter/01-create.md
@@ -1,0 +1,48 @@
+# Create Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - User`
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to group `Incoming Letter - User` — required later to Confirm this record; see
+  `04-confirm`.
+- **Data:** The **Partner**, **Internal Partner**, and **Letter Type** records used on
+  this document already exist.
+- **Access:** User is in group `Incoming Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner** _(required)_: Select the external partner (company) this letter was
+     received from.
+   - **Contact**: Select a contact belonging to the selected Partner. Optional — the
+     list is filtered to contacts of the chosen Partner and is automatically cleared
+     when **Partner** changes.
+   - **Internal Partner** _(required)_: Select the internal person (from your own
+     company) recording/receiving this letter.
+   - **Date** _(required)_: Enter the letter date.
+   - **Type** _(required)_: Select the **Letter Type**.
+   - **Title** _(required)_: Enter the subject/title of the letter.
+   - **Digital**: Check this box if the letter was received digitally. Leave unchecked
+     for a physical/paper letter.
+   - **Courier** _(required if **Digital** is unchecked)_: Select the courier that
+     delivered the physical letter. Hidden and not required when **Digital** is checked.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.
+- The document number shows **/** until the record reaches **Done** status (see
+  `05-approve`), when it is assigned automatically according to the sequence template
+  configuration.

--- a/ssi_letter/docs/incoming_letter/02-edit.md
+++ b/ssi_letter/docs/incoming_letter/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - User`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group `Incoming Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Find and open the record to edit.
+3. Change the required fields (Partner, Contact, Internal Partner, Date, Type, Title,
+   Digital, Courier).
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_letter/docs/incoming_letter/03-delete.md
+++ b/ssi_letter/docs/incoming_letter/03-delete.md
@@ -19,10 +19,10 @@
 ## Flow
 
 1. Open the **Letter ‣ Incoming Letters** menu.
-2. Select one or more records to delete (check the checkbox).
+2. Open the record to delete.
 3. Click **Action** ‣ **Delete**.
 4. Click **OK** to confirm.
 
 ## Post-Condition
 
-- The selected records are permanently removed from the system.
+- The record is permanently removed from the system.

--- a/ssi_letter/docs/incoming_letter/03-delete.md
+++ b/ssi_letter/docs/incoming_letter/03-delete.md
@@ -1,0 +1,28 @@
+# Delete Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - User`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group `Incoming Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** ‣ **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_letter/docs/incoming_letter/04-confirm.md
+++ b/ssi_letter/docs/incoming_letter/04-confirm.md
@@ -1,0 +1,36 @@
+# Confirm Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - User`
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants
+  `confirm_ok` for state `draft` to group `Incoming Letter - User`.
+- **Config:** The shipped "Standard" `approval.template` for this model matches this
+  record, with a single approval level whose approvers are drawn from group
+  `Incoming Letter - Validator`.
+- **Access:** User is in group `Incoming Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- An approval record is created for the pending approval level, drawn from the matching
+  approval template.

--- a/ssi_letter/docs/incoming_letter/05-approve.md
+++ b/ssi_letter/docs/incoming_letter/05-approve.md
@@ -1,0 +1,41 @@
+# Approve Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** approver on the pending approval level (drawn from group
+> `Incoming Letter - Validator`)
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` grants `approve_ok` to the actor
+  while they are registered as an active approver on the record.
+- **Config:** An active `sequence.template` exists for this model — required for the
+  document number that is generated automatically once this document reaches **Done**.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- If all approval levels are fulfilled, this document is automatically finished: status
+  changes straight to **Done**. There is no separate manual "Finish" step — this model
+  does not expose a Done button; the transition happens as soon as the last approval
+  level is fulfilled. Its document number is also generated automatically according to
+  the sequence template configuration.

--- a/ssi_letter/docs/incoming_letter/06-reject.md
+++ b/ssi_letter/docs/incoming_letter/06-reject.md
@@ -1,0 +1,33 @@
+# Reject Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** approver on the pending approval level (drawn from group
+> `Incoming Letter - Validator`)
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` grants `reject_ok` to the actor
+  while they are registered as an active approver on the record.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_letter/docs/incoming_letter/10-cancel.md
+++ b/ssi_letter/docs/incoming_letter/10-cancel.md
@@ -1,0 +1,33 @@
+# Cancel Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - Validator`
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** The shipped "Standard" `policy.template` grants `cancel_ok` for that state
+  to group `Incoming Letter - Validator`.
+- **Access:** User is in group `Incoming Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_letter/docs/incoming_letter/12-restart.md
+++ b/ssi_letter/docs/incoming_letter/12-restart.md
@@ -1,0 +1,36 @@
+# Restart Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - Validator`
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** The shipped "Standard" `policy.template` grants `restart_ok` for that
+  state to group `Incoming Letter - Validator`.
+- **Access:** User is in group `Incoming Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Remove the default state filter from the search bar, if the document does not appear
+   in the default list.
+3. Open the record to restart.
+4. Click the **Restart** button.
+5. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- If this document had already been confirmed, all its approval records are removed and
+  its Approval Template is cleared. A later Confirm starts the approval process from the
+  beginning.

--- a/ssi_letter/docs/incoming_letter/13-reset-number.md
+++ b/ssi_letter/docs/incoming_letter/13-reset-number.md
@@ -1,0 +1,33 @@
+# Reset Document Number — Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - Validator`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** The shipped "Standard" `policy.template` grants `manual_number_ok` for
+  state `draft` to group `Incoming Letter - Validator`.
+- **Access:** User is in group `Incoming Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field and change it to
+   **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** status,
+  according to the sequence template configuration.

--- a/ssi_letter/docs/incoming_letter/14-restart-approval.md
+++ b/ssi_letter/docs/incoming_letter/14-restart-approval.md
@@ -1,0 +1,47 @@
+# Restart Approval Process — Incoming Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `incoming_letter`
+>
+> **Menu:** Letter ‣ Incoming Letters
+>
+> **Actor:** user in group `Incoming Letter - Validator`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants
+  `restart_approval_ok` for state `confirm` to group `Incoming Letter - Validator`, but
+  only while the record has **no** Approval Template assigned yet (see note below).
+- **Access:** User is in group `Incoming Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Incoming Letters** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped "Standard" `policy.template` for `incoming_letter`
+> (`policy_template/incoming_letter.xml`) grants `restart_approval_ok` to group
+> `Incoming Letter - Validator` only when `document.approval_template_id` is **not**
+> set. Once Confirm has assigned an Approval Template to the record (the normal case for
+> a record confirmed with the shipped "Standard" `approval.template`), this policy
+> evaluates to **False** for every user, so the **Restart Approval Process** button is
+> present in the form (gate G1/G2 both pass at the code level — see the class attribute
+> `_automatically_insert_restart_approval_button` and `_policy_field_order`) but not
+> clickable under the default configuration. An administrator must adjust the
+> `policy.template_detail` row for `restart_approval_ok` before this button becomes
+> usable in that situation. This was found while writing this IK and is reported here
+> rather than fixed, since changing that row is a data/behavior change out of scope for
+> this Work Instruction.

--- a/ssi_letter/docs/internal_memo/01-create.md
+++ b/ssi_letter/docs/internal_memo/01-create.md
@@ -1,0 +1,39 @@
+# Create Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - User`
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to group `Internal Memo - User` — required later to Confirm this record; see
+  `04-confirm`.
+- **Data:** The **Internal Memo Type** record used on this document already exists.
+- **Access:** User is in group `Internal Memo - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Type** _(required)_: Select the **Internal Memo Type**.
+   - **Recipients**: Select the users this memo is addressed to. Optional.
+   - **Date** _(required)_: Enter the memo date.
+   - **Title** _(required)_: Enter the subject/title of the memo.
+4. Open the **Memo** tab and fill in:
+   - **Memo** _(required)_: Enter the memo content.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.
+- The document number shows **/** until the record reaches **Done** status (see
+  `05-approve`), when it is assigned automatically according to the sequence template
+  configuration.

--- a/ssi_letter/docs/internal_memo/02-edit.md
+++ b/ssi_letter/docs/internal_memo/02-edit.md
@@ -1,0 +1,27 @@
+# Edit Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - User`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group `Internal Memo - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Find and open the record to edit.
+3. Change the required fields (Type, Recipients, Date, Title, Memo).
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_letter/docs/internal_memo/03-delete.md
+++ b/ssi_letter/docs/internal_memo/03-delete.md
@@ -19,10 +19,10 @@
 ## Flow
 
 1. Open the **Letter ‣ Internal Memos** menu.
-2. Select one or more records to delete (check the checkbox).
+2. Open the record to delete.
 3. Click **Action** ‣ **Delete**.
 4. Click **OK** to confirm.
 
 ## Post-Condition
 
-- The selected records are permanently removed from the system.
+- The record is permanently removed from the system.

--- a/ssi_letter/docs/internal_memo/03-delete.md
+++ b/ssi_letter/docs/internal_memo/03-delete.md
@@ -1,0 +1,28 @@
+# Delete Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - User`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group `Internal Memo - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** ‣ **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_letter/docs/internal_memo/04-confirm.md
+++ b/ssi_letter/docs/internal_memo/04-confirm.md
@@ -1,0 +1,36 @@
+# Confirm Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - User`
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants
+  `confirm_ok` for state `draft` to group `Internal Memo - User`.
+- **Config:** The shipped "Standard" `approval.template` for this model matches this
+  record, with a single approval level whose approvers are drawn from group
+  `Internal Memo - Validator`.
+- **Access:** User is in group `Internal Memo - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- An approval record is created for the pending approval level, drawn from the matching
+  approval template.

--- a/ssi_letter/docs/internal_memo/05-approve.md
+++ b/ssi_letter/docs/internal_memo/05-approve.md
@@ -1,0 +1,41 @@
+# Approve Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** approver on the pending approval level (drawn from group
+> `Internal Memo - Validator`)
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` grants `approve_ok` to the actor
+  while they are registered as an active approver on the record.
+- **Config:** An active `sequence.template` exists for this model — required for the
+  document number that is generated automatically once this document reaches **Done**.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- If all approval levels are fulfilled, this document is automatically finished: status
+  changes straight to **Done**. There is no separate manual "Finish" step — this model
+  does not expose a Done button; the transition happens as soon as the last approval
+  level is fulfilled. Its document number is also generated automatically according to
+  the sequence template configuration.

--- a/ssi_letter/docs/internal_memo/06-reject.md
+++ b/ssi_letter/docs/internal_memo/06-reject.md
@@ -1,0 +1,33 @@
+# Reject Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** approver on the pending approval level (drawn from group
+> `Internal Memo - Validator`)
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` grants `reject_ok` to the actor
+  while they are registered as an active approver on the record.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_letter/docs/internal_memo/10-cancel.md
+++ b/ssi_letter/docs/internal_memo/10-cancel.md
@@ -1,0 +1,33 @@
+# Cancel Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - Validator`
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** The shipped "Standard" `policy.template` grants `cancel_ok` for that state
+  to group `Internal Memo - Validator`.
+- **Access:** User is in group `Internal Memo - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_letter/docs/internal_memo/12-restart.md
+++ b/ssi_letter/docs/internal_memo/12-restart.md
@@ -1,0 +1,36 @@
+# Restart Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - Validator`
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** The shipped "Standard" `policy.template` grants `restart_ok` for that
+  state to group `Internal Memo - Validator`.
+- **Access:** User is in group `Internal Memo - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Remove the default state filter from the search bar, if the document does not appear
+   in the default list.
+3. Open the record to restart.
+4. Click the **Restart** button.
+5. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- If this document had already been confirmed, all its approval records are removed and
+  its Approval Template is cleared. A later Confirm starts the approval process from the
+  beginning.

--- a/ssi_letter/docs/internal_memo/13-reset-number.md
+++ b/ssi_letter/docs/internal_memo/13-reset-number.md
@@ -1,0 +1,33 @@
+# Reset Document Number — Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - Validator`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** The shipped "Standard" `policy.template` grants `manual_number_ok` for
+  state `draft` to group `Internal Memo - Validator`.
+- **Access:** User is in group `Internal Memo - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field and change it to
+   **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done** status,
+  according to the sequence template configuration.

--- a/ssi_letter/docs/internal_memo/14-restart-approval.md
+++ b/ssi_letter/docs/internal_memo/14-restart-approval.md
@@ -1,0 +1,47 @@
+# Restart Approval Process — Internal Memo
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo`
+>
+> **Menu:** Letter ‣ Internal Memos
+>
+> **Actor:** user in group `Internal Memo - Validator`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants
+  `restart_approval_ok` for state `confirm` to group `Internal Memo - Validator`, but
+  only while the record has **no** Approval Template assigned yet (see note below).
+- **Access:** User is in group `Internal Memo - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Internal Memos** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped "Standard" `policy.template` for `internal_memo`
+> (`policy_template/internal_memo.xml`) grants `restart_approval_ok` to group
+> `Internal Memo - Validator` only when `document.approval_template_id` is **not** set.
+> Once Confirm has assigned an Approval Template to the record (the normal case for a
+> record confirmed with the shipped "Standard" `approval.template`), this policy
+> evaluates to **False** for every user, so the **Restart Approval Process** button is
+> present in the form (gate G1/G2 both pass at the code level — see the class attribute
+> `_automatically_insert_restart_approval_button` and `_policy_field_order`) but not
+> clickable under the default configuration. An administrator must adjust the
+> `policy.template_detail` row for `restart_approval_ok` before this button becomes
+> usable in that situation. This was found while writing this IK and is reported here
+> rather than fixed, since changing that row is a data/behavior change out of scope for
+> this Work Instruction.

--- a/ssi_letter/docs/internal_memo_type/01-create.md
+++ b/ssi_letter/docs/internal_memo_type/01-create.md
@@ -1,0 +1,35 @@
+# Create Internal Memo Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Internal Memo Types
+>
+> **Actor:** user in group `Internal Memo Type`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group `Internal Memo Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Internal Memo Types** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter the name of the internal memo type (e.g.
+     "Announcement", "Policy Update").
+   - **Code** _(required)_: Enter a unique code identifying this internal memo type, or
+     enter **/** to assign it later using **Generate Code**.
+4. Click **Generate Code** in the header to automatically assign a code from the
+   `sequence.template` configured for `internal_memo_type`. This requires an active
+   `sequence.template` for this model — without one, the action fails with an error. You
+   may also leave the Code field as **/** or type a code manually instead.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new Internal Memo Type record is created and active.
+- The new Internal Memo Type becomes selectable from the Type field of an Internal Memo.

--- a/ssi_letter/docs/internal_memo_type/02-edit.md
+++ b/ssi_letter/docs/internal_memo_type/02-edit.md
@@ -1,0 +1,36 @@
+# Edit Internal Memo Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Internal Memo Types
+>
+> **Actor:** user in group `Internal Memo Type`
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code), `action_reset_code` (Reset
+> code)
+
+## Pre-Condition
+
+- **Access:** User is in group `Internal Memo Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Internal Memo Types** menu.
+2. Find and open the record to edit.
+3. Change the required fields (Name, Code).
+4. Click **Generate Code** in the header to assign a code from the configured
+   `sequence.template`, if the Code field is still **/**. This requires an active
+   `sequence.template` for `internal_memo_type` — without one, the action fails with an
+   error. You may also type the code manually instead.
+5. Click **Save**.
+6. To make the record eligible for **Generate Code** again, go back to the **Internal
+   Memo Types** list, select the record's checkbox, click **Reset code** in the header,
+   then click **OK** to confirm. This resets the Code field back to **/**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_letter/docs/internal_memo_type/03-delete.md
+++ b/ssi_letter/docs/internal_memo_type/03-delete.md
@@ -1,0 +1,26 @@
+# Delete Internal Memo Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Internal Memo Types
+>
+> **Actor:** user in group `Internal Memo Type`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group `Internal Memo Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Internal Memo Types** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** ‣ **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_letter/docs/internal_memo_type/04-deactivate.md
+++ b/ssi_letter/docs/internal_memo_type/04-deactivate.md
@@ -1,0 +1,31 @@
+# Deactivate Internal Memo Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Internal Memo Types
+>
+> **Actor:** user in group `Internal Memo Type`
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Internal Memo Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Internal Memo Types** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** ‣ **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as **Type** on new Internal Memos.
+- Internal Memos that already use this record can still be viewed.

--- a/ssi_letter/docs/internal_memo_type/05-activate.md
+++ b/ssi_letter/docs/internal_memo_type/05-activate.md
@@ -1,0 +1,30 @@
+# Activate Internal Memo Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `internal_memo_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Internal Memo Types
+>
+> **Actor:** user in group `Internal Memo Type`
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Internal Memo Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Internal Memo Types** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** ‣ **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected as **Type** on new Internal Memos.

--- a/ssi_letter/docs/letter_type/01-create.md
+++ b/ssi_letter/docs/letter_type/01-create.md
@@ -1,0 +1,36 @@
+# Create Letter Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `letter_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Letter Types
+>
+> **Actor:** user in group `Letter Type`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group `Letter Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Letter Types** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter the name of the letter type (e.g. "Official Letter",
+     "Invitation").
+   - **Code** _(required)_: Enter a unique code identifying this letter type, or enter
+     **/** to assign it later using **Generate Code**.
+4. Click **Generate Code** in the header to automatically assign a code from the
+   `sequence.template` configured for `letter_type`. This requires an active
+   `sequence.template` for this model — without one, the action fails with an error. You
+   may also leave the Code field as **/** or type a code manually instead.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new Letter Type record is created and active.
+- The new Letter Type becomes selectable from the Type field of an Outgoing Letter or
+  Incoming Letter.

--- a/ssi_letter/docs/letter_type/02-edit.md
+++ b/ssi_letter/docs/letter_type/02-edit.md
@@ -1,0 +1,36 @@
+# Edit Letter Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `letter_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Letter Types
+>
+> **Actor:** user in group `Letter Type`
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code), `action_reset_code` (Reset
+> code)
+
+## Pre-Condition
+
+- **Access:** User is in group `Letter Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Letter Types** menu.
+2. Find and open the record to edit.
+3. Change the required fields (Name, Code).
+4. Click **Generate Code** in the header to assign a code from the configured
+   `sequence.template`, if the Code field is still **/**. This requires an active
+   `sequence.template` for `letter_type` — without one, the action fails with an error.
+   You may also type the code manually instead.
+5. Click **Save**.
+6. To make the record eligible for **Generate Code** again, go back to the **Letter
+   Types** list, select the record's checkbox, click **Reset code** in the header, then
+   click **OK** to confirm. This resets the Code field back to **/**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_letter/docs/letter_type/03-delete.md
+++ b/ssi_letter/docs/letter_type/03-delete.md
@@ -1,0 +1,26 @@
+# Delete Letter Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `letter_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Letter Types
+>
+> **Actor:** user in group `Letter Type`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Access:** User is in group `Letter Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Letter Types** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** ‣ **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_letter/docs/letter_type/04-deactivate.md
+++ b/ssi_letter/docs/letter_type/04-deactivate.md
@@ -1,0 +1,31 @@
+# Deactivate Letter Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `letter_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Letter Types
+>
+> **Actor:** user in group `Letter Type`
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group `Letter Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Letter Types** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** ‣ **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as **Type** on new Outgoing/Incoming Letters.
+- Outgoing/Incoming Letters that already use this record can still be viewed.

--- a/ssi_letter/docs/letter_type/05-activate.md
+++ b/ssi_letter/docs/letter_type/05-activate.md
@@ -1,0 +1,30 @@
+# Activate Letter Type
+
+> **Module:** ssi_letter
+>
+> **Model:** `letter_type`
+>
+> **Menu:** Letter ‣ Configuration ‣ Letter Types
+>
+> **Actor:** user in group `Letter Type`
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group `Letter Type`.
+
+## Flow
+
+1. Open the **Letter ‣ Configuration ‣ Letter Types** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** ‣ **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected as **Type** on new Outgoing/Incoming Letters.

--- a/ssi_letter/docs/outgoing_letter/01-create.md
+++ b/ssi_letter/docs/outgoing_letter/01-create.md
@@ -1,0 +1,48 @@
+# Create Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - User`
+>
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to group `Outgoing Letter - User` — required later to Confirm this record; see
+  `04-confirm`.
+- **Data:** The **Partner**, **Internal Partner**, and **Letter Type** records used on
+  this document already exist.
+- **Access:** User is in group `Outgoing Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner** _(required)_: Select the external partner (company) this letter is
+     addressed to.
+   - **Contact**: Select a contact belonging to the selected Partner. Optional — the
+     list is filtered to contacts of the chosen Partner and is automatically cleared
+     when **Partner** changes.
+   - **Internal Partner** _(required)_: Select the internal person (from your own
+     company) issuing this letter.
+   - **Date** _(required)_: Enter the letter date.
+   - **Type** _(required)_: Select the **Letter Type**.
+   - **Title** _(required)_: Enter the subject/title of the letter.
+   - **Digital**: Check this box if the letter is delivered digitally. Leave unchecked
+     for a physical/paper letter.
+   - **Courier** _(required if **Digital** is unchecked)_: Select the courier that
+     delivers the physical letter. Hidden and not required when **Digital** is checked.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.
+- The document number shows **/** until the record reaches **On Progress** status (see
+  `05-approve`), when it is assigned automatically according to the sequence template
+  configuration.

--- a/ssi_letter/docs/outgoing_letter/02-edit.md
+++ b/ssi_letter/docs/outgoing_letter/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - User`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group `Outgoing Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Find and open the record to edit.
+3. Change the required fields (Partner, Contact, Internal Partner, Date, Type, Title,
+   Digital, Courier).
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_letter/docs/outgoing_letter/03-delete.md
+++ b/ssi_letter/docs/outgoing_letter/03-delete.md
@@ -1,0 +1,28 @@
+# Delete Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - User`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group `Outgoing Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** ‣ **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_letter/docs/outgoing_letter/03-delete.md
+++ b/ssi_letter/docs/outgoing_letter/03-delete.md
@@ -19,10 +19,10 @@
 ## Flow
 
 1. Open the **Letter ‣ Outgoing Letters** menu.
-2. Select one or more records to delete (check the checkbox).
+2. Open the record to delete.
 3. Click **Action** ‣ **Delete**.
 4. Click **OK** to confirm.
 
 ## Post-Condition
 
-- The selected records are permanently removed from the system.
+- The record is permanently removed from the system.

--- a/ssi_letter/docs/outgoing_letter/04-confirm.md
+++ b/ssi_letter/docs/outgoing_letter/04-confirm.md
@@ -1,0 +1,36 @@
+# Confirm Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - User`
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants
+  `confirm_ok` for state `draft` to group `Outgoing Letter - User`.
+- **Config:** The shipped "Standard" `approval.template` for this model matches this
+  record, with a single approval level whose approvers are drawn from group
+  `Outgoing Letter - Validator`.
+- **Access:** User is in group `Outgoing Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- An approval record is created for the pending approval level, drawn from the matching
+  approval template.

--- a/ssi_letter/docs/outgoing_letter/05-approve.md
+++ b/ssi_letter/docs/outgoing_letter/05-approve.md
@@ -1,0 +1,42 @@
+# Approve Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** approver on the pending approval level (drawn from group
+> `Outgoing Letter - Validator`)
+>
+> **State:** `confirm` → `open`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` grants `approve_ok` to the actor
+  while they are registered as an active approver on the record.
+- **Config:** An active `sequence.template` exists for this model — required for the
+  document number that is generated automatically once this document reaches **On
+  Progress**.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- If all approval levels are fulfilled, this document is automatically opened: status
+  changes straight to **On Progress**. There is no separate manual "Start" step — the
+  transition happens as soon as the last approval level is fulfilled. Its document
+  number is also generated automatically according to the sequence template
+  configuration.

--- a/ssi_letter/docs/outgoing_letter/06-reject.md
+++ b/ssi_letter/docs/outgoing_letter/06-reject.md
@@ -1,0 +1,33 @@
+# Reject Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** approver on the pending approval level (drawn from group
+> `Outgoing Letter - Validator`)
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` grants `reject_ok` to the actor
+  while they are registered as an active approver on the record.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_letter/docs/outgoing_letter/09-finish.md
+++ b/ssi_letter/docs/outgoing_letter/09-finish.md
@@ -1,0 +1,31 @@
+# Finish Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - User`
+>
+> **State:** `open` → `done`
+>
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants `done_ok`
+  for state `open` to group `Outgoing Letter - User`.
+- **Access:** User is in group `Outgoing Letter - User`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record to finish.
+3. Click the **Done** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.

--- a/ssi_letter/docs/outgoing_letter/10-cancel.md
+++ b/ssi_letter/docs/outgoing_letter/10-cancel.md
@@ -1,0 +1,34 @@
+# Cancel Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - Validator`
+>
+> **State:** `draft` | `confirm` | `open` | `done` → `cancel`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, **On Progress**, or
+  **Done**.
+- **Config:** The shipped "Standard" `policy.template` grants `cancel_ok` for that state
+  to group `Outgoing Letter - Validator`.
+- **Access:** User is in group `Outgoing Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_letter/docs/outgoing_letter/12-restart.md
+++ b/ssi_letter/docs/outgoing_letter/12-restart.md
@@ -1,0 +1,36 @@
+# Restart Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - Validator`
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** The shipped "Standard" `policy.template` grants `restart_ok` for that
+  state to group `Outgoing Letter - Validator`.
+- **Access:** User is in group `Outgoing Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Remove the default state filter from the search bar, if the document does not appear
+   in the default list.
+3. Open the record to restart.
+4. Click the **Restart** button.
+5. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- If this document had already been confirmed, all its approval records are removed and
+  its Approval Template is cleared. A later Confirm starts the approval process from the
+  beginning.

--- a/ssi_letter/docs/outgoing_letter/13-reset-number.md
+++ b/ssi_letter/docs/outgoing_letter/13-reset-number.md
@@ -1,0 +1,33 @@
+# Reset Document Number — Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - Validator`
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** The shipped "Standard" `policy.template` grants `manual_number_ok` for
+  state `draft` to group `Outgoing Letter - Validator`.
+- **Access:** User is in group `Outgoing Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the number field and change it to
+   **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **On Progress**
+  status, according to the sequence template configuration.

--- a/ssi_letter/docs/outgoing_letter/14-restart-approval.md
+++ b/ssi_letter/docs/outgoing_letter/14-restart-approval.md
@@ -1,0 +1,47 @@
+# Restart Approval Process — Outgoing Letter
+
+> **Module:** ssi_letter
+>
+> **Model:** `outgoing_letter`
+>
+> **Menu:** Letter ‣ Outgoing Letters
+>
+> **Actor:** user in group `Outgoing Letter - Validator`
+>
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** The shipped "Standard" `policy.template` for this model grants
+  `restart_approval_ok` for state `confirm` to group `Outgoing Letter - Validator`, but
+  only while the record has **no** Approval Template assigned yet (see note below).
+- **Access:** User is in group `Outgoing Letter - Validator`.
+
+## Flow
+
+1. Open the **Letter ‣ Outgoing Letters** menu.
+2. Open the record to restart the approval process for.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- All existing approval records for this document are removed.
+- New approval records are created from the record's current **Approval Template**,
+  restarting the approval process from the first level.
+- Status remains **Waiting for Approval**.
+
+> **Note:** the shipped "Standard" `policy.template` for `outgoing_letter`
+> (`policy_template/outgoing_letter.xml`) grants `restart_approval_ok` to group
+> `Outgoing Letter - Validator` only when `document.approval_template_id` is **not**
+> set. Once Confirm has assigned an Approval Template to the record (the normal case for
+> a record confirmed with the shipped "Standard" `approval.template`), this policy
+> evaluates to **False** for every user, so the **Restart Approval Process** button is
+> present in the form (gate G1/G2 both pass at the code level — see the class attribute
+> `_automatically_insert_restart_approval_button` and `_policy_field_order`) but not
+> clickable under the default configuration. An administrator must adjust the
+> `policy.template_detail` row for `restart_approval_ok` before this button becomes
+> usable in that situation. This was found while writing this IK and is reported here
+> rather than fixed, since changing that row is a data/behavior change out of scope for
+> this Work Instruction.

--- a/ssi_letter/static/tests/tours/incoming_letter_tour.js
+++ b/ssi_letter/static/tests/tours/incoming_letter_tour.js
@@ -1,0 +1,607 @@
+odoo.define("ssi_letter.incoming_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Flow 1 of every IK in this file: "Open the Letter > Incoming Letters
+    // menu." "Incoming Letters" (menuitem) has no children, so it renders
+    // as a plain leaf item directly in the app navbar (patterns.md "Jumlah
+    // level menu di IK != jumlah step tour"). The breadcrumb gate checks
+    // the ACTION title ("Incoming Letter", singular — see
+    // views/incoming_letter_views.xml), not the menu label.
+    var openIncomingLetterList = function () {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Incoming Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.incoming_letter_menu"]',
+            },
+            {
+                content: "Incoming Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Incoming Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    };
+
+    // IK: docs/incoming_letter/01-create.md
+    tour.register(
+        "ssi_letter_incoming_letter_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Select the Partner",
+                trigger: ".o_field_many2one[name='partner_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR IL Partner",
+            },
+            {
+                content: "Pick the Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR IL Partner)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Internal Partner",
+                trigger: ".o_field_many2one[name='internal_partner_id'] input",
+                run: "text TOUR-IL-CREATE",
+            },
+            {
+                content: "Pick the Internal Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-IL-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/15/2026",
+            },
+            {
+                content: "Select the Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                run: "text TOUR IL Type",
+            },
+            {
+                content: "Pick the Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR IL Type)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Title",
+                trigger: ".o_field_widget[name='title']",
+                run: "text TOUR Incoming Letter Create",
+            },
+            {
+                // Checking Digital hides/un-requires Courier, so this create
+                // tour does not need a Courier fixture to be able to save.
+                content: "Check Digital",
+                trigger: ".o_field_widget[name='digital'] input",
+                run: "click",
+            },
+
+            // Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — a new record is created in Draft status.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/02-edit.md
+    tour.register(
+        "ssi_letter_incoming_letter_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Change the required fields.
+            {
+                content: "Change the Title",
+                trigger: ".o_field_widget[name='title']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Incoming Letter Edited",
+            },
+
+            // Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — the record is updated with the new values.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/03-delete.md
+    tour.register(
+        "ssi_letter_incoming_letter_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Select the record to delete.
+            {
+                content: "Select the record's checkbox",
+                trigger:
+                    ".o_data_row:contains(TOUR-IL-DELETE) .o_list_record_selector input",
+                run: "click",
+            },
+
+            // Flow 3 — Click Action > Delete.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record is permanently removed.
+            {
+                content: "Record is removed from the list",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(TOUR-IL-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/04-confirm.md
+    tour.register(
+        "ssi_letter_incoming_letter_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Open the record to confirm.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Waiting for Approval.
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/05-approve.md
+    tour.register(
+        "ssi_letter_incoming_letter_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — all approval levels fulfilled: the document
+            // is automatically finished, status jumps straight to Done.
+            // This model has no Done button (_automatically_insert_done_
+            // button = False) — the transition only happens this way.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/06-reject.md
+    tour.register(
+        "ssi_letter_incoming_letter_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Open the record to reject.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/10-cancel.md
+    tour.register(
+        "ssi_letter_incoming_letter_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Open the record to cancel.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Cancel button.
+            // type="action" (opens base_select_cancel_reason_action) — the
+            // rendered `name` is a resolved numeric action id, so this
+            // targets the button by its label instead (selectors.md §4).
+            {
+                content: "Click the Cancel button",
+                trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — In the wizard, select the Cancellation Reason.
+            // cancel_reason_id uses widget="radio" here, not an
+            // autocomplete — click the matching radio label directly.
+            {
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Select the cancellation reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] .o_radio_item label:contains(TOUR IL Cancel Reason)",
+            },
+
+            // Flow 5 — Click Confirm. The wizard's own Confirm button
+            // carries confirm="Are you sure?" — a SECOND dialog stacks on
+            // top of the wizard (overview.md, "confirm= di dalam wizard").
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+
+            // Flow 6 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Cancelled.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/12-restart.md
+    tour.register(
+        "ssi_letter_incoming_letter_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2/3 — The default list has no active state filter, so
+            // the Cancelled fixture is already visible here — open it
+            // directly.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 5 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/13-reset-number.md
+    tour.register(
+        "ssi_letter_incoming_letter_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Open the record whose document number will be reset.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-RESET) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reset Document Number button.
+            {
+                content: "Click the Reset Document Number button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reset_document_number']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — document number returns to "/". The fixture
+            // was created with the manual number "TOUR-IL-RESET-NUM"
+            // (litmus test: this selector cannot match before Reset runs).
+            {
+                content: "Document number returns to /",
+                trigger:
+                    ".o_form_view .o_field_widget[name='display_name']:not(:contains(TOUR-IL-RESET-NUM))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/incoming_letter/14-restart-approval.md
+    tour.register(
+        "ssi_letter_incoming_letter_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openIncomingLetterList(), [
+            // Flow 2 — Open the record to restart the approval process for.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-REAPPROVAL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Restart Approval Process button.
+            {
+                content: "Click the Restart Approval Process button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status remains Waiting for Approval.
+            {
+                content: "Status is still Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_letter/static/tests/tours/incoming_letter_tour.js
+++ b/ssi_letter/static/tests/tours/incoming_letter_tour.js
@@ -196,12 +196,27 @@ odoo.define("ssi_letter.incoming_letter_tour", function (require) {
             url: "/web",
         },
         [].concat(openIncomingLetterList(), [
-            // Flow 2 — Select the record to delete.
+            // Flow 2 — Open the record to delete.
+            // Deleting via the list checkbox proved non-deterministic in
+            // CI for the sibling outgoing_letter tour: the checkbox toggle
+            // sometimes never registers (row stays unselected,
+            // `.o_cp_action_menus` never renders — Odoo14 only mounts it
+            // once selectedRecords.length > 0). Deleting from the FORM's
+            // Action menu instead does not depend on list selection state
+            // at all — see patterns.md §I ("Checkbox list rapuh di 14.0 ...
+            // Membuka record lalu delete dari Action menu form jauh lebih
+            // deterministik").
             {
-                content: "Select the record's checkbox",
-                trigger:
-                    ".o_data_row:contains(TOUR-IL-DELETE) .o_list_record_selector input",
-                run: "click",
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IL-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
             },
 
             // Flow 3 — Click Action > Delete.
@@ -227,6 +242,14 @@ odoo.define("ssi_letter.incoming_letter_tour", function (require) {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
+            },
+
+            // After delete, 14.0 can display the NEXT record in the list
+            // instead of returning to the list itself. Click the
+            // breadcrumb explicitly before asserting the list.
+            {
+                content: "Click the Incoming Letter breadcrumb",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Incoming Letter)",
             },
 
             // Post-Condition — the record is permanently removed.

--- a/ssi_letter/static/tests/tours/internal_memo_tour.js
+++ b/ssi_letter/static/tests/tours/internal_memo_tour.js
@@ -180,12 +180,27 @@ odoo.define("ssi_letter.internal_memo_tour", function (require) {
             url: "/web",
         },
         [].concat(openInternalMemoList(), [
-            // Flow 2 — Select the record to delete.
+            // Flow 2 — Open the record to delete.
+            // Deleting via the list checkbox proved non-deterministic in
+            // CI for the sibling outgoing_letter tour: the checkbox toggle
+            // sometimes never registers (row stays unselected,
+            // `.o_cp_action_menus` never renders — Odoo14 only mounts it
+            // once selectedRecords.length > 0). Deleting from the FORM's
+            // Action menu instead does not depend on list selection state
+            // at all — see patterns.md §I ("Checkbox list rapuh di 14.0 ...
+            // Membuka record lalu delete dari Action menu form jauh lebih
+            // deterministik").
             {
-                content: "Select the record's checkbox",
-                trigger:
-                    ".o_data_row:contains(TOUR-IM-DELETE) .o_list_record_selector input",
-                run: "click",
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
             },
 
             // Flow 3 — Click Action > Delete.
@@ -211,6 +226,14 @@ odoo.define("ssi_letter.internal_memo_tour", function (require) {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
+            },
+
+            // After delete, 14.0 can display the NEXT record in the list
+            // instead of returning to the list itself. Click the
+            // breadcrumb explicitly before asserting the list.
+            {
+                content: "Click the Internal Memo breadcrumb",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Internal Memo)",
             },
 
             // Post-Condition — the record is permanently removed.

--- a/ssi_letter/static/tests/tours/internal_memo_tour.js
+++ b/ssi_letter/static/tests/tours/internal_memo_tour.js
@@ -1,0 +1,591 @@
+odoo.define("ssi_letter.internal_memo_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Flow 1 of every IK in this file: "Open the Letter > Internal Memos
+    // menu." "Internal Memos" (menuitem) has no children, so it renders as
+    // a plain leaf item directly in the app navbar (patterns.md "Jumlah
+    // level menu di IK != jumlah step tour"). The breadcrumb gate checks
+    // the ACTION title ("Internal Memo", singular — see
+    // views/internal_memo.xml), not the menu label.
+    var openInternalMemoList = function () {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Internal Memos menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_menu"]',
+            },
+            {
+                content: "Internal Memo list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    };
+
+    // IK: docs/internal_memo/01-create.md
+    tour.register(
+        "ssi_letter_internal_memo_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in Type, Date, Title.
+            {
+                content: "Select the Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR IM Type",
+            },
+            {
+                content: "Pick the Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR IM Type)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/15/2026",
+            },
+            {
+                content: "Fill in the Title",
+                trigger: ".o_field_widget[name='title']",
+                run: "text TOUR Internal Memo Create",
+            },
+
+            // Flow 4 — Open the Memo tab and fill in Memo.
+            {
+                content: "Open the Memo tab",
+                trigger: ".o_notebook .nav-link:contains(Memo)",
+            },
+            {
+                content: "Fill in the Memo",
+                trigger: ".o_field_widget[name='memo'] .note-editable",
+                run: "text TOUR Internal Memo body content.",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — a new record is created in Draft status.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/02-edit.md
+    tour.register(
+        "ssi_letter_internal_memo_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Change the required fields.
+            {
+                content: "Change the Title",
+                trigger: ".o_field_widget[name='title']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Internal Memo Edited",
+            },
+
+            // Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — the record is updated with the new values.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/03-delete.md
+    tour.register(
+        "ssi_letter_internal_memo_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Select the record to delete.
+            {
+                content: "Select the record's checkbox",
+                trigger:
+                    ".o_data_row:contains(TOUR-IM-DELETE) .o_list_record_selector input",
+                run: "click",
+            },
+
+            // Flow 3 — Click Action > Delete.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record is permanently removed.
+            {
+                content: "Record is removed from the list",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(TOUR-IM-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/04-confirm.md
+    tour.register(
+        "ssi_letter_internal_memo_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Open the record to confirm.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Waiting for Approval.
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/05-approve.md
+    tour.register(
+        "ssi_letter_internal_memo_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — all approval levels fulfilled: the document
+            // is automatically finished, status jumps straight to Done.
+            // This model has no Done button (_automatically_insert_done_
+            // button = False) — the transition only happens this way.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/06-reject.md
+    tour.register(
+        "ssi_letter_internal_memo_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Open the record to reject.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/10-cancel.md
+    tour.register(
+        "ssi_letter_internal_memo_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Open the record to cancel.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Cancel button.
+            // type="action" (opens base_select_cancel_reason_action) — the
+            // rendered `name` is a resolved numeric action id, so this
+            // targets the button by its label instead (selectors.md §4).
+            {
+                content: "Click the Cancel button",
+                trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — In the wizard, select the Cancellation Reason.
+            // cancel_reason_id uses widget="radio" here, not an
+            // autocomplete — click the matching radio label directly.
+            {
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Select the cancellation reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] .o_radio_item label:contains(TOUR IM Cancel Reason)",
+            },
+
+            // Flow 5 — Click Confirm. The wizard's own Confirm button
+            // carries confirm="Are you sure?" — a SECOND dialog stacks on
+            // top of the wizard (overview.md, "confirm= di dalam wizard").
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+
+            // Flow 6 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Cancelled.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/12-restart.md
+    tour.register(
+        "ssi_letter_internal_memo_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2/3 — The default list has no active state filter, so
+            // the Cancelled fixture is already visible here — open it
+            // directly.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 5 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/13-reset-number.md
+    tour.register(
+        "ssi_letter_internal_memo_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Open the record whose document number will be reset.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-RESET) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reset Document Number button.
+            {
+                content: "Click the Reset Document Number button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reset_document_number']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — document number returns to "/". The fixture
+            // was created with the manual number "TOUR-IM-RESET-NUM"
+            // (litmus test: this selector cannot match before Reset runs).
+            {
+                content: "Document number returns to /",
+                trigger:
+                    ".o_form_view .o_field_widget[name='display_name']:not(:contains(TOUR-IM-RESET-NUM))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/internal_memo/14-restart-approval.md
+    tour.register(
+        "ssi_letter_internal_memo_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openInternalMemoList(), [
+            // Flow 2 — Open the record to restart the approval process for.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-IM-REAPPROVAL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Restart Approval Process button.
+            {
+                content: "Click the Restart Approval Process button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status remains Waiting for Approval.
+            {
+                content: "Status is still Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_letter/static/tests/tours/internal_memo_type_tour.js
+++ b/ssi_letter/static/tests/tours/internal_memo_type_tour.js
@@ -1,0 +1,424 @@
+odoo.define("ssi_letter.internal_memo_type_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/internal_memo_type/01-create.md
+    tour.register(
+        "ssi_letter_internal_memo_type_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Internal Memo Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Internal Memo Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_type_menu"]',
+            },
+            {
+                content: "Internal Memo Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Internal Memo Type Create",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+
+            // Flow 5 — Click Save
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — record is created and active
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/internal_memo_type/02-edit.md
+    tour.register(
+        "ssi_letter_internal_memo_type_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Internal Memo Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Internal Memo Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_type_menu"]',
+            },
+            {
+                content: "Internal Memo Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Find and open the record to edit
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Internal Memo Type Edit) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Change the required fields
+            {
+                content: "Change the Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Internal Memo Type Edited",
+            },
+
+            // Flow 5 — Click Save
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — the record is updated with the new values
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/internal_memo_type/03-delete.md
+    tour.register(
+        "ssi_letter_internal_memo_type_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Internal Memo Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Internal Memo Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_type_menu"]',
+            },
+            {
+                content: "Internal Memo Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Select the record to delete
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Internal Memo Type Delete) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 3 — Click Action > Delete
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record no longer appears in the list
+            {
+                content: "Record is removed from the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR Internal Memo Type Delete)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/internal_memo_type/04-deactivate.md
+    tour.register(
+        "ssi_letter_internal_memo_type_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Internal Memo Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Internal Memo Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_type_menu"]',
+            },
+            {
+                content: "Internal Memo Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Select the record to deactivate
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Internal Memo Type Deactivate) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 3 — Click Action > Archive
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Archive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $archive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Archive";
+                        }
+                    );
+                    $archive[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm
+            {
+                content: "Confirm archiving",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record no longer appears in the default list view
+            {
+                content: "Record is removed from the default list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR Internal Memo Type Deactivate)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/internal_memo_type/05-activate.md
+    tour.register(
+        "ssi_letter_internal_memo_type_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Internal Memo Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Internal Memo Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_type_menu"]',
+            },
+            {
+                content: "Internal Memo Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Enable the Archived filter
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .dropdown-item:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Archived filter is active",
+                trigger: ".o_facet_values:contains(Archived)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Select the record to reactivate
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Internal Memo Type Activate) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 4 — Click Action > Unarchive
+            // Unarchive has NO confirmation dialog (list_controller.js:490) — do not
+            // wait for a modal after this click.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+
+            // Post-Condition — the record is restored and appears in the default list
+            {
+                content: "Record is restored to the default list",
+                trigger:
+                    ".o_list_view .o_data_row:contains(TOUR Internal Memo Type Activate)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter/static/tests/tours/letter_type_tour.js
+++ b/ssi_letter/static/tests/tours/letter_type_tour.js
@@ -1,0 +1,423 @@
+odoo.define("ssi_letter.letter_type_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/letter_type/01-create.md
+    tour.register(
+        "ssi_letter_letter_type_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Letter Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Letter Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.letter_type_menu"]',
+            },
+            {
+                content: "Letter Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Letter Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Letter Type Create",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+
+            // Flow 5 — Click Save
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — record is created and active
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/letter_type/02-edit.md
+    tour.register(
+        "ssi_letter_letter_type_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Letter Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Letter Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.letter_type_menu"]',
+            },
+            {
+                content: "Letter Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Letter Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Find and open the record to edit
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Letter Type Edit) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Change the required fields
+            {
+                content: "Change the Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Letter Type Edited",
+            },
+
+            // Flow 5 — Click Save
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — the record is updated with the new values
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/letter_type/03-delete.md
+    tour.register(
+        "ssi_letter_letter_type_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Letter Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Letter Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.letter_type_menu"]',
+            },
+            {
+                content: "Letter Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Letter Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Select the record to delete
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Letter Type Delete) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 3 — Click Action > Delete
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record no longer appears in the list
+            {
+                content: "Record is removed from the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR Letter Type Delete)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/letter_type/04-deactivate.md
+    tour.register(
+        "ssi_letter_letter_type_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Letter Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Letter Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.letter_type_menu"]',
+            },
+            {
+                content: "Letter Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Letter Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Select the record to deactivate
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Letter Type Deactivate) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 3 — Click Action > Archive
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Archive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $archive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Archive";
+                        }
+                    );
+                    $archive[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm
+            {
+                content: "Confirm archiving",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record no longer appears in the default list view
+            {
+                content: "Record is removed from the default list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR Letter Type Deactivate)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/letter_type/05-activate.md
+    tour.register(
+        "ssi_letter_letter_type_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Letter > Configuration > Letter Types menu
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.menu_letter_configuration"]',
+            },
+            {
+                content: "Open the Letter Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.letter_type_menu"]',
+            },
+            {
+                content: "Letter Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Letter Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Enable the Archived filter
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .dropdown-item:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Archived filter is active",
+                trigger: ".o_facet_values:contains(Archived)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Select the record to reactivate
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR Letter Type Activate) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 4 — Click Action > Unarchive
+            // Unarchive has NO confirmation dialog (list_controller.js:490) — do not
+            // wait for a modal after this click.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+
+            // Post-Condition — the record is restored and appears in the default list
+            {
+                content: "Record is restored to the default list",
+                trigger: ".o_list_view .o_data_row:contains(TOUR Letter Type Activate)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter/static/tests/tours/outgoing_letter_tour.js
+++ b/ssi_letter/static/tests/tours/outgoing_letter_tour.js
@@ -196,12 +196,28 @@ odoo.define("ssi_letter.outgoing_letter_tour", function (require) {
             url: "/web",
         },
         [].concat(openOutgoingLetterList(), [
-            // Flow 2 — Select the record to delete.
+            // Flow 2 — Open the record to delete.
+            // Deleting via the list checkbox (`run: "click"` on
+            // `.o_list_record_selector input`) proved non-deterministic in
+            // CI here: the checkbox toggle sometimes never registers (the
+            // row stays unselected and `.o_cp_action_menus` never renders,
+            // since Odoo14 only mounts it once selectedRecords.length > 0),
+            // so the tour times out on "Open the Action menu". Deleting
+            // from the FORM's Action menu instead does not depend on list
+            // selection state at all — see patterns.md §I ("Checkbox list
+            // rapuh di 14.0 ... Membuka record lalu delete dari Action menu
+            // form jauh lebih deterministik").
             {
-                content: "Select the record's checkbox",
-                trigger:
-                    ".o_data_row:contains(TOUR-OL-DELETE) .o_list_record_selector input",
-                run: "click",
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
             },
 
             // Flow 3 — Click Action > Delete.
@@ -227,6 +243,14 @@ odoo.define("ssi_letter.outgoing_letter_tour", function (require) {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
+            },
+
+            // After delete, 14.0 can display the NEXT record in the list
+            // instead of returning to the list itself. Click the
+            // breadcrumb explicitly before asserting the list.
+            {
+                content: "Click the Outgoing Letter breadcrumb",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Outgoing Letter)",
             },
 
             // Post-Condition — the record is permanently removed.

--- a/ssi_letter/static/tests/tours/outgoing_letter_tour.js
+++ b/ssi_letter/static/tests/tours/outgoing_letter_tour.js
@@ -1,0 +1,654 @@
+odoo.define("ssi_letter.outgoing_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Flow 1 of every IK in this file: "Open the Letter > Outgoing Letters
+    // menu." "Outgoing Letters" (menuitem) has no children, so it renders as
+    // a plain leaf item directly in the app navbar (patterns.md "Jumlah
+    // level menu di IK != jumlah step tour"). The breadcrumb gate checks the
+    // ACTION title ("Outgoing Letter", singular — see
+    // views/outgoing_letter_views.xml), not the menu label.
+    var openOutgoingLetterList = function () {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Outgoing Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.outgoing_letter_menu"]',
+            },
+            {
+                content: "Outgoing Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Outgoing Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    };
+
+    // IK: docs/outgoing_letter/01-create.md
+    tour.register(
+        "ssi_letter_outgoing_letter_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Click the New button.
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Select the Partner",
+                trigger: ".o_field_many2one[name='partner_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR OL Partner",
+            },
+            {
+                content: "Pick the Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR OL Partner)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Internal Partner",
+                trigger: ".o_field_many2one[name='internal_partner_id'] input",
+                run: "text TOUR-OL-CREATE",
+            },
+            {
+                content: "Pick the Internal Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-OL-CREATE)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/15/2026",
+            },
+            {
+                content: "Select the Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                run: "text TOUR OL Type",
+            },
+            {
+                content: "Pick the Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR OL Type)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Title",
+                trigger: ".o_field_widget[name='title']",
+                run: "text TOUR Outgoing Letter Create",
+            },
+            {
+                // Checking Digital hides/un-requires Courier, so this create
+                // tour does not need a Courier fixture to be able to save.
+                content: "Check Digital",
+                trigger: ".o_field_widget[name='digital'] input",
+                run: "click",
+            },
+
+            // Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — a new record is created in Draft status.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/02-edit.md
+    tour.register(
+        "ssi_letter_outgoing_letter_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Record is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Change the required fields.
+            {
+                content: "Change the Title",
+                trigger: ".o_field_widget[name='title']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Outgoing Letter Edited",
+            },
+
+            // Flow 4 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — the record is updated with the new values.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/03-delete.md
+    tour.register(
+        "ssi_letter_outgoing_letter_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Select the record to delete.
+            {
+                content: "Select the record's checkbox",
+                trigger:
+                    ".o_data_row:contains(TOUR-OL-DELETE) .o_list_record_selector input",
+                run: "click",
+            },
+
+            // Flow 3 — Click Action > Delete.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the record is permanently removed.
+            {
+                content: "Record is removed from the list",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(TOUR-OL-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/04-confirm.md
+    tour.register(
+        "ssi_letter_outgoing_letter_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record to confirm.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Waiting for Approval.
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/05-approve.md
+    tour.register(
+        "ssi_letter_outgoing_letter_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — all approval levels fulfilled: the document is
+            // automatically opened, status jumps straight to On Progress.
+            {
+                content: "Status is On Progress",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/06-reject.md
+    tour.register(
+        "ssi_letter_outgoing_letter_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record to reject.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/09-finish.md
+    tour.register(
+        "ssi_letter_outgoing_letter_finish",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record to finish.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-FINISH) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Done button.
+            {
+                content: "Click the Done button",
+                trigger: ".o_statusbar_buttons button[name='action_done']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Done.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/10-cancel.md
+    tour.register(
+        "ssi_letter_outgoing_letter_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record to cancel.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Cancel button.
+            // type="action" (opens base_select_cancel_reason_action) — the
+            // rendered `name` is a resolved numeric action id, so this
+            // targets the button by its label instead (selectors.md §4).
+            {
+                content: "Click the Cancel button",
+                trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — In the wizard, select the Cancellation Reason.
+            // cancel_reason_id uses widget="radio" here, not an
+            // autocomplete — click the matching radio label directly.
+            {
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Select the cancellation reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] .o_radio_item label:contains(TOUR OL Cancel Reason)",
+            },
+
+            // Flow 5 — Click Confirm. The wizard's own Confirm button
+            // carries confirm="Are you sure?" — a SECOND dialog stacks on
+            // top of the wizard (overview.md, "confirm= di dalam wizard").
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+
+            // Flow 6 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status changes to Cancelled.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/12-restart.md
+    tour.register(
+        "ssi_letter_outgoing_letter_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2/3 — The default list has no active state filter (the
+            // search view defines dom_* filters but none is enabled by
+            // default), so the Cancelled fixture is already visible here —
+            // open it directly.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 5 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/13-reset-number.md
+    tour.register(
+        "ssi_letter_outgoing_letter_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record whose document number will be reset.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-RESET) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reset Document Number button.
+            {
+                content: "Click the Reset Document Number button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reset_document_number']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — document number returns to "/". The fixture
+            // was created with the manual number "TOUR-OL-RESET-NUM"
+            // (litmus test: this selector cannot match before Reset runs,
+            // since the field still shows that manual number then).
+            {
+                content: "Document number returns to /",
+                trigger:
+                    ".o_form_view .o_field_widget[name='display_name']:not(:contains(TOUR-OL-RESET-NUM))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/outgoing_letter/14-restart-approval.md
+    tour.register(
+        "ssi_letter_outgoing_letter_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openOutgoingLetterList(), [
+            // Flow 2 — Open the record to restart the approval process for.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-OL-REAPPROVAL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Restart Approval Process button.
+            {
+                content: "Click the Restart Approval Process button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — status remains Waiting for Approval.
+            {
+                content: "Status is still Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_letter/tests/__init__.py
+++ b/ssi_letter/tests/__init__.py
@@ -7,4 +7,9 @@ from . import (  # noqa: F401
     test_outgoing_letter,
     test_incoming_letter,
     test_internal_memo,
+    test_ui_letter_type,
+    test_ui_internal_memo_type,
+    test_ui_outgoing_letter,
+    test_ui_incoming_letter,
+    test_ui_internal_memo,
 )

--- a/ssi_letter/tests/test_ui_incoming_letter.py
+++ b/ssi_letter/tests/test_ui_incoming_letter.py
@@ -1,0 +1,197 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiIncomingLetter(HttpSavepointCase):
+    """Tour tests for the ``incoming_letter`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the ``incoming_letter`` fixtures each tour needs.
+
+        ``incoming_letter_validator_group`` already grants
+        ``base.user_admin`` membership by default (see
+        ``security/res_groups/incoming_letter.xml``) and implies both the
+        user and viewer groups, so ``admin`` can run every tour here
+        (including approving, since the shipped "Standard"
+        ``approval.template`` draws its approvers from the same
+        Validator group) without any extra group setup.
+
+        Every fixture record's ``user_id`` is set explicitly to
+        ``admin`` — ``cls.env`` runs as SUPERUSER here, and the record
+        rule ``incoming_letter_internal_user_rule`` would otherwise hide
+        records owned by someone else from the ``admin`` tour session.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        company_partner = cls.env.company.partner_id
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "TOUR IL Partner", "is_company": True}
+        )
+        cls.letter_type = cls.env["letter_type"].create(
+            {"name": "TOUR IL Type", "code": "/"}
+        )
+        # Used by the create tour to search for an Internal Partner via the
+        # many2one autocomplete — not reused by any other fixture record.
+        cls.env["res.partner"].create(
+            {
+                "name": "TOUR-IL-CREATE",
+                "parent_id": company_partner.id,
+                "is_company": False,
+            }
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR IL Cancel Reason",
+                "code": "TOURIL",
+                "global_use": True,
+            }
+        )
+
+        cls.rec_edit = cls._create_letter("TOUR-IL-EDIT")
+        cls.rec_delete = cls._create_letter("TOUR-IL-DELETE")
+        cls.rec_confirm = cls._create_letter("TOUR-IL-CONFIRM")
+
+        cls.rec_approve = cls._create_letter("TOUR-IL-APPROVE")
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+        cls.rec_reject = cls._create_letter("TOUR-IL-REJECT")
+        cls.rec_reject.with_user(cls.admin).action_confirm()
+        cls.rec_reject.invalidate_cache()
+
+        cls.rec_cancel = cls._create_letter("TOUR-IL-CANCEL")
+
+        cls.rec_restart = cls._create_letter("TOUR-IL-RESTART")
+        cls.rec_restart.with_user(cls.admin).action_confirm()
+        cls.rec_restart.invalidate_cache()
+        cls.rec_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+        cls.rec_restart.invalidate_cache()
+
+        # IK Pre-Condition of 13-reset-number: a manually-assigned number,
+        # so the tour can observe it change back to "/".
+        cls.rec_reset = cls._create_letter("TOUR-IL-RESET", name="TOUR-IL-RESET-NUM")
+
+        # IK Pre-Condition of 14-restart-approval: Status is Waiting for
+        # Approval, with NO Approval Template assigned (see the note in
+        # docs/incoming_letter/14-restart-approval.md) — under the shipped
+        # "Standard" policy.template, restart_approval_ok only evaluates
+        # True while approval_template_id is empty. A normal Confirm always
+        # assigns one, so this fixture clears it back out afterwards to
+        # exercise the button the IK documents.
+        cls.rec_restart_approval = cls._create_letter("TOUR-IL-REAPPROVAL")
+        cls.rec_restart_approval.with_user(cls.admin).action_confirm()
+        cls.rec_restart_approval.write({"approval_template_id": False})
+        cls.rec_restart_approval.invalidate_cache()
+
+    @classmethod
+    def _create_letter(cls, tag, name=False):
+        """Create one draft ``incoming_letter`` fixture.
+
+        :param tag: name for a dedicated Internal Partner, also used by
+            the tours to locate the row in the list view (the Internal
+            Partner column is always visible there)
+        :param name: manual document number to assign, or a falsy value
+            to keep the default "/"
+        :return: the created ``incoming_letter`` record
+        :rtype: :class:`IncomingLetter`
+        """
+        internal_partner = cls.env["res.partner"].create(
+            {
+                "name": tag,
+                "parent_id": cls.env.company.partner_id.id,
+                "is_company": False,
+            }
+        )
+        vals = {
+            "partner_id": cls.partner.id,
+            "internal_partner_id": internal_partner.id,
+            "type_id": cls.letter_type.id,
+            "date": "2026-01-15",
+            "title": "TOUR Incoming Letter %s" % tag,
+            "digital": True,
+            "user_id": cls.admin.id,
+        }
+        if name:
+            vals["name"] = name
+        return cls.env["incoming_letter"].create(vals)
+
+    def test_create(self):
+        """Run the create tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/01-create.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/02-edit.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/03-delete.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_delete", login="admin")
+
+    def test_confirm(self):
+        """Run the confirm tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/04-confirm.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_confirm", login="admin")
+
+    def test_approve(self):
+        """Run the approve tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/05-approve.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_approve", login="admin")
+
+    def test_reject(self):
+        """Run the reject tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/06-reject.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_reject", login="admin")
+
+    def test_cancel(self):
+        """Run the cancel tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/10-cancel.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_cancel", login="admin")
+
+    def test_restart(self):
+        """Run the restart tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/12-restart.md
+        """
+        self.start_tour("/web", "ssi_letter_incoming_letter_restart", login="admin")
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/13-reset-number.md
+        """
+        self.start_tour(
+            "/web", "ssi_letter_incoming_letter_reset_number", login="admin"
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web", "ssi_letter_incoming_letter_restart_approval", login="admin"
+        )

--- a/ssi_letter/tests/test_ui_internal_memo.py
+++ b/ssi_letter/tests/test_ui_internal_memo.py
@@ -1,0 +1,176 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiInternalMemo(HttpSavepointCase):
+    """Tour tests for the ``internal_memo`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the ``internal_memo`` fixtures each tour needs.
+
+        ``internal_memo_validator_group`` already grants
+        ``base.user_admin`` membership by default (see
+        ``security/res_groups/internal_memo.xml``) and implies both the
+        user and viewer groups, so ``admin`` can run every tour here
+        (including approving, since the shipped "Standard"
+        ``approval.template`` draws its approvers from the same
+        Validator group) without any extra group setup.
+
+        Every fixture record's ``user_id`` is set explicitly to
+        ``admin`` — ``cls.env`` runs as SUPERUSER here, and the record
+        rule ``internal_memo_internal_user_rule`` would otherwise hide
+        records owned by someone else from the ``admin`` tour session.
+        ``title`` doubles as the unique row-locator token: unlike
+        ``outgoing_letter``/``incoming_letter``, ``internal_memo``'s
+        tree view (``views/internal_memo.xml``) shows the Title column.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        cls.memo_type = cls.env["internal_memo_type"].create(
+            {"name": "TOUR IM Type", "code": "/"}
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR IM Cancel Reason",
+                "code": "TOURIM",
+                "global_use": True,
+            }
+        )
+
+        cls.rec_edit = cls._create_memo("TOUR-IM-EDIT")
+        cls.rec_delete = cls._create_memo("TOUR-IM-DELETE")
+        cls.rec_confirm = cls._create_memo("TOUR-IM-CONFIRM")
+
+        cls.rec_approve = cls._create_memo("TOUR-IM-APPROVE")
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+        cls.rec_reject = cls._create_memo("TOUR-IM-REJECT")
+        cls.rec_reject.with_user(cls.admin).action_confirm()
+        cls.rec_reject.invalidate_cache()
+
+        cls.rec_cancel = cls._create_memo("TOUR-IM-CANCEL")
+
+        cls.rec_restart = cls._create_memo("TOUR-IM-RESTART")
+        cls.rec_restart.with_user(cls.admin).action_confirm()
+        cls.rec_restart.invalidate_cache()
+        cls.rec_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+        cls.rec_restart.invalidate_cache()
+
+        # IK Pre-Condition of 13-reset-number: a manually-assigned number,
+        # so the tour can observe it change back to "/".
+        cls.rec_reset = cls._create_memo("TOUR-IM-RESET", name="TOUR-IM-RESET-NUM")
+
+        # IK Pre-Condition of 14-restart-approval: Status is Waiting for
+        # Approval, with NO Approval Template assigned (see the note in
+        # docs/internal_memo/14-restart-approval.md) — under the shipped
+        # "Standard" policy.template, restart_approval_ok only evaluates
+        # True while approval_template_id is empty. A normal Confirm always
+        # assigns one, so this fixture clears it back out afterwards to
+        # exercise the button the IK documents.
+        cls.rec_restart_approval = cls._create_memo("TOUR-IM-REAPPROVAL")
+        cls.rec_restart_approval.with_user(cls.admin).action_confirm()
+        cls.rec_restart_approval.write({"approval_template_id": False})
+        cls.rec_restart_approval.invalidate_cache()
+
+    @classmethod
+    def _create_memo(cls, tag, name=False):
+        """Create one draft ``internal_memo`` fixture.
+
+        :param tag: value for the ``title`` field, used by the tours to
+            locate the row in the list view (the Title column is
+            always visible there)
+        :param name: manual document number to assign, or a falsy value
+            to keep the default "/"
+        :return: the created ``internal_memo`` record
+        :rtype: :class:`InternalMemo`
+        """
+        vals = {
+            "type_id": cls.memo_type.id,
+            "date": "2026-01-15",
+            "title": tag,
+            "memo": "<p>TOUR Internal Memo body content.</p>",
+            "user_id": cls.admin.id,
+        }
+        if name:
+            vals["name"] = name
+        return cls.env["internal_memo"].create(vals)
+
+    def test_create(self):
+        """Run the create tour for ``internal_memo``.
+
+        IK: docs/internal_memo/01-create.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``internal_memo``.
+
+        IK: docs/internal_memo/02-edit.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``internal_memo``.
+
+        IK: docs/internal_memo/03-delete.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_delete", login="admin")
+
+    def test_confirm(self):
+        """Run the confirm tour for ``internal_memo``.
+
+        IK: docs/internal_memo/04-confirm.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_confirm", login="admin")
+
+    def test_approve(self):
+        """Run the approve tour for ``internal_memo``.
+
+        IK: docs/internal_memo/05-approve.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_approve", login="admin")
+
+    def test_reject(self):
+        """Run the reject tour for ``internal_memo``.
+
+        IK: docs/internal_memo/06-reject.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_reject", login="admin")
+
+    def test_cancel(self):
+        """Run the cancel tour for ``internal_memo``.
+
+        IK: docs/internal_memo/10-cancel.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_cancel", login="admin")
+
+    def test_restart(self):
+        """Run the restart tour for ``internal_memo``.
+
+        IK: docs/internal_memo/12-restart.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_restart", login="admin")
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``internal_memo``.
+
+        IK: docs/internal_memo/13-reset-number.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_reset_number", login="admin")
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``internal_memo``.
+
+        IK: docs/internal_memo/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web", "ssi_letter_internal_memo_restart_approval", login="admin"
+        )

--- a/ssi_letter/tests/test_ui_internal_memo_type.py
+++ b/ssi_letter/tests/test_ui_internal_memo_type.py
@@ -1,0 +1,77 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiInternalMemoType(HttpSavepointCase):
+    """Tour tests for the ``internal_memo_type`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the ``internal_memo_type`` records the tours edit/toggle.
+
+        The ``internal_memo_type_group`` group already grants
+        ``base.user_admin`` membership by default (see
+        ``security/res_groups/internal_memo_type.xml``), so no extra group
+        setup is required for the ``admin`` user running these tours.
+        """
+        super().setUpClass()
+        Type = cls.env["internal_memo_type"]
+        cls.type_edit = Type.create(
+            {"name": "TOUR Internal Memo Type Edit", "code": "/"}
+        )
+        cls.type_delete = Type.create(
+            {"name": "TOUR Internal Memo Type Delete", "code": "/"}
+        )
+        cls.type_deactivate = Type.create(
+            {"name": "TOUR Internal Memo Type Deactivate", "code": "/"}
+        )
+        cls.type_activate = Type.create(
+            {
+                "name": "TOUR Internal Memo Type Activate",
+                "code": "/",
+                "active": False,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``internal_memo_type``.
+
+        IK: docs/internal_memo_type/01-create.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_type_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``internal_memo_type``.
+
+        IK: docs/internal_memo_type/02-edit.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_type_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``internal_memo_type``.
+
+        IK: docs/internal_memo_type/03-delete.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_type_delete", login="admin")
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``internal_memo_type``.
+
+        IK: docs/internal_memo_type/04-deactivate.md
+        """
+        self.start_tour(
+            "/web", "ssi_letter_internal_memo_type_deactivate", login="admin"
+        )
+
+    def test_activate(self):
+        """Run the activate tour for ``internal_memo_type``.
+
+        IK: docs/internal_memo_type/05-activate.md
+        """
+        self.start_tour("/web", "ssi_letter_internal_memo_type_activate", login="admin")

--- a/ssi_letter/tests/test_ui_letter_type.py
+++ b/ssi_letter/tests/test_ui_letter_type.py
@@ -1,0 +1,71 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiLetterType(HttpSavepointCase):
+    """Tour tests for the ``letter_type`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the ``letter_type`` records the tours edit/delete/toggle.
+
+        The ``letter_type_group`` group already grants ``base.user_admin``
+        membership by default (see
+        ``security/res_groups/letter_type.xml``), so no extra group setup
+        is required for the ``admin`` user running these tours.
+        """
+        super().setUpClass()
+        Type = cls.env["letter_type"]
+        cls.type_edit = Type.create({"name": "TOUR Letter Type Edit", "code": "/"})
+        cls.type_delete = Type.create({"name": "TOUR Letter Type Delete", "code": "/"})
+        cls.type_deactivate = Type.create(
+            {"name": "TOUR Letter Type Deactivate", "code": "/"}
+        )
+        cls.type_activate = Type.create(
+            {
+                "name": "TOUR Letter Type Activate",
+                "code": "/",
+                "active": False,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``letter_type``.
+
+        IK: docs/letter_type/01-create.md
+        """
+        self.start_tour("/web", "ssi_letter_letter_type_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``letter_type``.
+
+        IK: docs/letter_type/02-edit.md
+        """
+        self.start_tour("/web", "ssi_letter_letter_type_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``letter_type``.
+
+        IK: docs/letter_type/03-delete.md
+        """
+        self.start_tour("/web", "ssi_letter_letter_type_delete", login="admin")
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``letter_type``.
+
+        IK: docs/letter_type/04-deactivate.md
+        """
+        self.start_tour("/web", "ssi_letter_letter_type_deactivate", login="admin")
+
+    def test_activate(self):
+        """Run the activate tour for ``letter_type``.
+
+        IK: docs/letter_type/05-activate.md
+        """
+        self.start_tour("/web", "ssi_letter_letter_type_activate", login="admin")

--- a/ssi_letter/tests/test_ui_outgoing_letter.py
+++ b/ssi_letter/tests/test_ui_outgoing_letter.py
@@ -1,0 +1,219 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiOutgoingLetter(HttpSavepointCase):
+    """Tour tests for the ``outgoing_letter`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the ``outgoing_letter`` fixtures each tour needs.
+
+        ``outgoing_letter_validator_group`` already grants
+        ``base.user_admin`` membership by default (see
+        ``security/res_groups/outgoing_letter.xml``) and implies both the
+        user and viewer groups, so ``admin`` can run every tour here
+        (including approving, since the shipped "Standard"
+        ``approval.template`` draws its approvers from the same
+        Validator group) without any extra group setup.
+
+        Every fixture record's ``user_id`` is set explicitly to
+        ``admin`` — ``cls.env`` runs as SUPERUSER here, and the record
+        rule ``outgoing_letter_internal_user_rule`` would otherwise hide
+        records owned by someone else from the ``admin`` tour session.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        company_partner = cls.env.company.partner_id
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "TOUR OL Partner", "is_company": True}
+        )
+        cls.letter_type = cls.env["letter_type"].create(
+            {"name": "TOUR OL Type", "code": "/"}
+        )
+        # Used by the create tour to search for an Internal Partner via the
+        # many2one autocomplete — not reused by any other fixture record.
+        cls.env["res.partner"].create(
+            {
+                "name": "TOUR-OL-CREATE",
+                "parent_id": company_partner.id,
+                "is_company": False,
+            }
+        )
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR OL Cancel Reason",
+                "code": "TOUROL",
+                "global_use": True,
+            }
+        )
+
+        cls.rec_edit = cls._create_letter("TOUR-OL-EDIT")
+        cls.rec_delete = cls._create_letter("TOUR-OL-DELETE")
+        cls.rec_confirm = cls._create_letter("TOUR-OL-CONFIRM")
+
+        cls.rec_approve = cls._create_letter("TOUR-OL-APPROVE")
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+        cls.rec_reject = cls._create_letter("TOUR-OL-REJECT")
+        cls.rec_reject.with_user(cls.admin).action_confirm()
+        cls.rec_reject.invalidate_cache()
+
+        cls.rec_finish = cls._create_letter("TOUR-OL-FINISH")
+        cls._run_to_open(cls.rec_finish)
+
+        cls.rec_cancel = cls._create_letter("TOUR-OL-CANCEL")
+
+        cls.rec_restart = cls._create_letter("TOUR-OL-RESTART")
+        cls.rec_restart.with_user(cls.admin).action_confirm()
+        cls.rec_restart.invalidate_cache()
+        cls.rec_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+        cls.rec_restart.invalidate_cache()
+
+        # IK Pre-Condition of 13-reset-number: a manually-assigned number,
+        # so the tour can observe it change back to "/".
+        cls.rec_reset = cls._create_letter("TOUR-OL-RESET", name="TOUR-OL-RESET-NUM")
+
+        # IK Pre-Condition of 14-restart-approval: Status is Waiting for
+        # Approval, with NO Approval Template assigned (see the note in
+        # docs/outgoing_letter/14-restart-approval.md) — under the shipped
+        # "Standard" policy.template, restart_approval_ok only evaluates
+        # True while approval_template_id is empty. A normal Confirm always
+        # assigns one, so this fixture clears it back out afterwards to
+        # exercise the button the IK documents.
+        cls.rec_restart_approval = cls._create_letter("TOUR-OL-REAPPROVAL")
+        cls.rec_restart_approval.with_user(cls.admin).action_confirm()
+        cls.rec_restart_approval.write({"approval_template_id": False})
+        cls.rec_restart_approval.invalidate_cache()
+
+    @classmethod
+    def _create_letter(cls, tag, name=False):
+        """Create one draft ``outgoing_letter`` fixture.
+
+        :param tag: name for a dedicated Internal Partner, also used by
+            the tours to locate the row in the list view (the Internal
+            Partner column is always visible there)
+        :param name: manual document number to assign, or a falsy value
+            to keep the default "/"
+        :return: the created ``outgoing_letter`` record
+        :rtype: :class:`OutgoingLetter`
+        """
+        internal_partner = cls.env["res.partner"].create(
+            {
+                "name": tag,
+                "parent_id": cls.env.company.partner_id.id,
+                "is_company": False,
+            }
+        )
+        vals = {
+            "partner_id": cls.partner.id,
+            "internal_partner_id": internal_partner.id,
+            "type_id": cls.letter_type.id,
+            "date": "2026-01-15",
+            "title": "TOUR Outgoing Letter %s" % tag,
+            "digital": True,
+            "user_id": cls.admin.id,
+        }
+        if name:
+            vals["name"] = name
+        return cls.env["outgoing_letter"].create(vals)
+
+    @classmethod
+    def _run_to_open(cls, record):
+        """Confirm then approve ``record`` as ``admin`` so it reaches Open.
+
+        :param record: the ``outgoing_letter`` record to advance
+        :return: nothing
+        """
+        record.with_user(cls.admin).action_confirm()
+        record.invalidate_cache()
+        record.with_user(cls.admin).action_approve_approval()
+        record.invalidate_cache()
+
+    def test_create(self):
+        """Run the create tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/01-create.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/02-edit.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/03-delete.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_delete", login="admin")
+
+    def test_confirm(self):
+        """Run the confirm tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/04-confirm.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_confirm", login="admin")
+
+    def test_approve(self):
+        """Run the approve tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/05-approve.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_approve", login="admin")
+
+    def test_reject(self):
+        """Run the reject tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/06-reject.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_reject", login="admin")
+
+    def test_finish(self):
+        """Run the finish tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/09-finish.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_finish", login="admin")
+
+    def test_cancel(self):
+        """Run the cancel tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/10-cancel.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_cancel", login="admin")
+
+    def test_restart(self):
+        """Run the restart tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/12-restart.md
+        """
+        self.start_tour("/web", "ssi_letter_outgoing_letter_restart", login="admin")
+
+    def test_reset_number(self):
+        """Run the reset document number tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/13-reset-number.md
+        """
+        self.start_tour(
+            "/web", "ssi_letter_outgoing_letter_reset_number", login="admin"
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web", "ssi_letter_outgoing_letter_restart_approval", login="admin"
+        )

--- a/ssi_letter/views/assets.xml
+++ b/ssi_letter/views/assets.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--Copyright 2026 OpenSynergy Indonesia-->
+<!--Copyright 2026 PT. Simetri Sinergi Indonesia-->
+<!--License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).-->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_letter assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_letter/static/tests/tours/letter_type_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_letter/static/tests/tours/internal_memo_type_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_letter/static/tests/tours/outgoing_letter_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_letter/static/tests/tours/incoming_letter_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_letter/static/tests/tours/internal_memo_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Summary

- Menambahkan direktori `docs/` berisi Instruksi Kerja (IK) untuk kelima model ber-permukaan pengguna di `ssi_letter`: `letter_type`, `internal_memo_type`, `outgoing_letter`, `incoming_letter`, `internal_memo`.
- `letter_type` dan `internal_memo_type` memakai template IK master data (create, edit, delete, deactivate, activate).
- `outgoing_letter`, `incoming_letter`, `internal_memo` memakai template IK transaksional sesuai state machine masing-masing:
  - `outgoing_letter`: `mixin.transaction_confirm` + `open` + `done` + `cancel`; confirm → open otomatis via approval, lalu tombol Done tersedia untuk open → done.
  - `incoming_letter` dan `internal_memo`: `mixin.transaction_confirm` + `done` + `cancel` — **tanpa** state `open`; transisi ke done terjadi otomatis via approval (tanpa tombol Done).
  - `mixin.letter` (AbstractModel) tidak mendapat IK sendiri, sesuai Keputusan Desain issue.
- Menambahkan satu tour Odoo per berkas IK (41 tour total), didaftarkan ke bundle `web.assets_tests` lewat `views/assets.xml`, plus `HttpCase` Python per model di `tests/test_ui_*.py`.
- Menambahkan dependensi `web_tour` di `__manifest__.py`.
- Memperbarui `README.rst` dengan bagian Work Instruction.
- Sinkronisasi config files dengan standar `ssi-mixin` (commit terpisah).

Closes #12

## Test plan

- [ ] CI hijau: pre-commit (black/prettier/eslint/pylint_odoo), unit test yaml, dan tour Odoo
- [ ] Validator `ik` dan `tour` modul `ssi_letter` tidak melaporkan ERROR (`odoo-development-instruksi-kerja/assets/validate-ik.sh` dan `odoo-development-ui-test/assets/validate-tour.sh` — sudah dijalankan lokal, 0 ERROR)