### PR TITLE
[UPD] ssi_letter_operating_unit - cakupan OU untuk internal_memo

### DIFF
--- a/ssi_letter_operating_unit/__manifest__.py
+++ b/ssi_letter_operating_unit/__manifest__.py
@@ -16,10 +16,13 @@
     "data": [
         "security/res_group/outgoing_letter.xml",
         "security/res_group/incoming_letter.xml",
+        "security/res_group/internal_memo.xml",
         "security/ir_rule/outgoing_letter.xml",
         "security/ir_rule/incoming_letter.xml",
+        "security/ir_rule/internal_memo.xml",
         "views/outgoing_letter_views.xml",
         "views/incoming_letter_views.xml",
+        "views/internal_memo_views.xml",
     ],
     "demo": [],
     "images": [],

--- a/ssi_letter_operating_unit/models/__init__.py
+++ b/ssi_letter_operating_unit/models/__init__.py
@@ -3,5 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
 from . import (
     incoming_letter,
+    internal_memo,
     outgoing_letter,
 )

--- a/ssi_letter_operating_unit/models/internal_memo.py
+++ b/ssi_letter_operating_unit/models/internal_memo.py
@@ -1,0 +1,19 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
+
+from odoo import models
+
+
+class InternalMemo(models.Model):
+    """
+    Adds Operating Unit ownership to internal memo documents.
+    Brings internal_memo in line with incoming_letter and
+    outgoing_letter, which already carry the operating_unit_id field.
+    """
+
+    _name = "internal_memo"
+    _inherit = [
+        "internal_memo",
+        "mixin.single_operating_unit",
+    ]

--- a/ssi_letter_operating_unit/security/ir_rule/internal_memo.xml
+++ b/ssi_letter_operating_unit/security/ir_rule/internal_memo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="internal_memo_rule_ou" model="ir.rule">
+    <field name="name">Internal Memo - Responsible to operating unit data</field>
+    <field name="model_id" ref="ssi_letter.model_internal_memo" />
+    <field name="groups" eval="[(4, ref('internal_memo_ou_group'))]" />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+</odoo>

--- a/ssi_letter_operating_unit/security/res_group/internal_memo.xml
+++ b/ssi_letter_operating_unit/security/res_group/internal_memo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<!-- Data Ownership -->
+<record id="internal_memo_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_letter.internal_memo_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_letter.internal_memo_company_group" model="res.groups">
+    <field name="name">Company</field>
+    <field
+            name="category_id"
+            ref="ssi_letter.internal_memo_data_ownership_module_category"
+        />
+    <field name="implied_ids" eval="[(4, ref('internal_memo_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>

--- a/ssi_letter_operating_unit/tests/test_data_letter_operating_unit.yaml
+++ b/ssi_letter_operating_unit/tests/test_data_letter_operating_unit.yaml
@@ -72,3 +72,33 @@ scenarios:
           id:
             type: "value"
             operator: "is_truthy"
+
+  - name: "Internal Memo - Has operating_unit_id field"
+    steps:
+      - step: "Create internal memo type"
+        action: "create"
+        model: "internal_memo_type"
+        save_as: "memo_type"
+        values:
+          name: "Test Internal Memo Type OU"
+          code: "TIMTOU"
+
+      - step: "Create internal memo"
+        action: "create"
+        model: "internal_memo"
+        save_as: "memo"
+        as_user: "base.user_admin"
+        values:
+          type_id: "EVAL: registry['memo_type'].id"
+          date: 2026-01-15
+          title: "Test Internal Memo OU"
+          memo: "Test memo content OU"
+          operating_unit_id: "REF: operating_unit.main_operating_unit"
+
+      - step: "Assert internal memo has operating_unit_id"
+        action: "assert"
+        target: "memo"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_truthy"

--- a/ssi_letter_operating_unit/views/internal_memo_views.xml
+++ b/ssi_letter_operating_unit/views/internal_memo_views.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="internal_memo_view_tree" model="ir.ui.view">
+    <field name="name">internal_memo tree</field>
+    <field name="model">internal_memo</field>
+    <field name="inherit_id" ref="ssi_letter.internal_memo_view_tree" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="internal_memo_view_search" model="ir.ui.view">
+    <field name="name">internal_memo search</field>
+    <field name="model">internal_memo</field>
+    <field name="inherit_id" ref="ssi_letter.internal_memo_view_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="internal_memo_view_form" model="ir.ui.view">
+    <field name="name">internal_memo form</field>
+    <field name="model">internal_memo</field>
+    <field name="inherit_id" ref="ssi_letter.internal_memo_view_form" />
+    <field name="arch" type="xml">
+      <data>
+          <xpath expr="//field[@name='company_id']" position="after">
+              <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+          </xpath>
+      </data>
+    </field>
+</record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan cakupan Operating Unit (`mixin.single_operating_unit`, field
`operating_unit_id`) untuk model `internal_memo` pada modul
`ssi_letter_operating_unit`, konsisten dengan `incoming_letter` dan
`outgoing_letter` yang sudah dicakup modul ini.

* Model baru `internal_memo` (`_inherit = ["internal_memo", "mixin.single_operating_unit"]`)
* Security: `res_group`/`ir_rule` untuk `internal_memo`, pola sama dengan model existing
* View: field `operating_unit_id` setelah `company_id` pada tree/search/form,
  filter groupby `grp_ou` di search
* `__manifest__.py` didaftarkan ke seluruh berkas baru
* Skenario `odoo-yaml-test` baru untuk `internal_memo` di
  `tests/test_data_letter_operating_unit.yaml`

Model `incoming_letter` dan `outgoing_letter` yang sudah ada tidak disentuh.

Closes #11