### PR TITLE
[UPD] ssi_letter - Lengkapi docstring seluruh class & method

### DIFF
--- a/ssi_letter/models/incoming_letter.py
+++ b/ssi_letter/models/incoming_letter.py
@@ -8,6 +8,13 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class IncomingLetter(models.Model):
+    """
+    Track a letter received from an external partner.
+    Manages the confirm/approve/done/cancel workflow of an incoming
+    letter, including approval and sequence numbering on the ``done``
+    state.
+    """
+
     _name = "incoming_letter"
     _inherit = [
         "mixin.letter",

--- a/ssi_letter/models/internal_memo.py
+++ b/ssi_letter/models/internal_memo.py
@@ -8,6 +8,13 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class InternalMemo(models.Model):
+    """
+    Track a memo circulated internally to a list of recipients.
+    Manages the confirm/approve/done/cancel workflow of an internal
+    memo, including approval and sequence numbering on the ``done``
+    state.
+    """
+
     _name = "internal_memo"
     _inherit = [
         "mixin.transaction_cancel",

--- a/ssi_letter/models/internal_memo_type.py
+++ b/ssi_letter/models/internal_memo_type.py
@@ -6,6 +6,12 @@ from odoo import models
 
 
 class InternalMemoType(models.Model):
+    """
+    Master data classifying the kind of an internal memo.
+    Used to categorize ``internal_memo`` records for numbering,
+    reporting, and filtering purposes.
+    """
+
     _name = "internal_memo_type"
     _inherit = [
         "mixin.master_data",

--- a/ssi_letter/models/letter_mixin.py
+++ b/ssi_letter/models/letter_mixin.py
@@ -6,6 +6,14 @@ from odoo import fields, models
 
 
 class LetterMixin(models.AbstractModel):
+    """
+    Common fields shared by every kind of letter document.
+    Provides the type, date, title, courier, and partner fields that
+    ``incoming_letter`` and ``outgoing_letter`` inherit, on top of the
+    transaction/partner workflow already supplied by
+    ``mixin.transaction_partner``.
+    """
+
     _name = "mixin.letter"
     _inherit = [
         "mixin.transaction_partner",

--- a/ssi_letter/models/letter_type.py
+++ b/ssi_letter/models/letter_type.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class LetterType(models.Model):
+    """
+    Master data classifying the kind of a letter.
+    Used by ``mixin.letter`` (``type_id``) to categorize
+    ``incoming_letter`` and ``outgoing_letter`` records for numbering,
+    reporting, and filtering purposes.
+    """
+
     _name = "letter_type"
     _inherit = [
         "mixin.master_data",

--- a/ssi_letter/models/outgoing_letter.py
+++ b/ssi_letter/models/outgoing_letter.py
@@ -8,6 +8,13 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class OutgoingLetter(models.Model):
+    """
+    Track a letter sent to an external partner.
+    Manages the confirm/approve/open/done/cancel workflow of an
+    outgoing letter, including approval and sequence numbering on
+    the ``open`` state.
+    """
+
     _name = "outgoing_letter"
     _inherit = [
         "mixin.letter",

--- a/ssi_letter/tests/test_incoming_letter.py
+++ b/ssi_letter/tests/test_incoming_letter.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestIncomingLetter(YamlTransactionCase):
+    """Test the ``incoming_letter`` confirm/approve/done workflow."""
+
     def test_incoming_letter(self):
+        """Run the full workflow and restart-from-confirm scenarios."""
         self.run_yaml_scenario("test_data_incoming_letter.yaml")

--- a/ssi_letter/tests/test_internal_memo.py
+++ b/ssi_letter/tests/test_internal_memo.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestInternalMemo(YamlTransactionCase):
+    """Test the ``internal_memo`` confirm/approve/done workflow."""
+
     def test_internal_memo(self):
+        """Run the full workflow and restart-from-confirm scenarios."""
         self.run_yaml_scenario("test_data_internal_memo.yaml")

--- a/ssi_letter/tests/test_letter_type.py
+++ b/ssi_letter/tests/test_letter_type.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestLetterType(YamlTransactionCase):
+    """Test creation of ``letter_type`` and ``internal_memo_type``."""
+
     def test_letter_type(self):
+        """Run the letter type and internal memo type creation scenario."""
         self.run_yaml_scenario("test_data_letter_type.yaml")

--- a/ssi_letter/tests/test_outgoing_letter.py
+++ b/ssi_letter/tests/test_outgoing_letter.py
@@ -9,5 +9,8 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestOutgoingLetter(YamlTransactionCase):
+    """Test the ``outgoing_letter`` confirm/approve/open/done workflow."""
+
     def test_outgoing_letter(self):
+        """Run the full workflow and restart-from-confirm scenarios."""
         self.run_yaml_scenario("test_data_outgoing_letter.yaml")


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring pada seluruh class & method di `models/` dan `tests/`
modul `ssi_letter` sesuai format baku SSI (Inggris, gaya reST, ≤ 79
karakter per baris), menyelesaikan temuan sapuan kepatuhan 14.0:

- `setiap-class-method-punya-docstring` (validator `module`, 14 butir)
- `setiap-class-method-test-punya-docstring` (validator `unit-test`, 8 butir)

**Perubahan:**
- Docstring class model: `letter_mixin.py`, `letter_type.py`,
  `internal_memo_type.py`, `incoming_letter.py`, `internal_memo.py`,
  `outgoing_letter.py`
- Docstring class test & method `test_*`: `test_incoming_letter.py`,
  `test_internal_memo.py`, `test_letter_type.py`, `test_outgoing_letter.py`

Tidak ada perubahan perilaku, penamaan, atau tanda tangan method apa pun —
murni penambahan docstring.

Closes #13

## Test plan

- [x] `verify-module.sh ssi_letter 14.0` — docstring section `[12]` lolos
- [x] `validate-unit-test.sh ssi_letter 14.0` — docstring section `[3]` lolos
- [x] `pre-commit-gate.sh` — `GATE OK: 6 pemeriksaan, 0 pelanggaran baru`
- [x] CI GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)