### PR TITLE
[UPD] ssi_letter_documenso_signing - Lengkapi docstring

### DIFF
--- a/ssi_letter_documenso_signing/models/incoming_letter.py
+++ b/ssi_letter_documenso_signing/models/incoming_letter.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class IncomingLetter(models.Model):
+    """Enable Documenso-based approval signing for incoming letters.
+
+    Extends ``incoming_letter`` with ``mixin.documenso_signing_approval``
+    and turns on the Documenso Signing form tab, so an approval template
+    with a Documenso signing template routes approval through a single
+    ``documenso.signature.request`` instead of standard approval records.
+    """
+
     _name = "incoming_letter"
     _inherit = [
         "incoming_letter",

--- a/ssi_letter_documenso_signing/models/internal_memo.py
+++ b/ssi_letter_documenso_signing/models/internal_memo.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class InternalMemo(models.Model):
+    """Enable Documenso-based approval signing for internal memos.
+
+    Extends ``internal_memo`` with ``mixin.documenso_signing_approval``
+    and turns on the Documenso Signing form tab, so an approval template
+    with a Documenso signing template routes approval through a single
+    ``documenso.signature.request`` instead of standard approval records.
+    """
+
     _name = "internal_memo"
     _inherit = [
         "internal_memo",

--- a/ssi_letter_documenso_signing/models/outgoing_letter.py
+++ b/ssi_letter_documenso_signing/models/outgoing_letter.py
@@ -6,6 +6,14 @@ from odoo import models
 
 
 class OutgoingLetter(models.Model):
+    """Enable Documenso-based approval signing for outgoing letters.
+
+    Extends ``outgoing_letter`` with ``mixin.documenso_signing_approval``
+    and turns on the Documenso Signing form tab, so an approval template
+    with a Documenso signing template routes approval through a single
+    ``documenso.signature.request`` instead of standard approval records.
+    """
+
     _name = "outgoing_letter"
     _inherit = [
         "outgoing_letter",

--- a/ssi_letter_documenso_signing/tests/test_letter_documenso_signing_approval.py
+++ b/ssi_letter_documenso_signing/tests/test_letter_documenso_signing_approval.py
@@ -9,5 +9,15 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestLetterDocumensoSigningApproval(YamlTransactionCase):
+    """Test the Documenso signing approval glue for ssi_letter models.
+
+    Covers ``outgoing_letter``, ``incoming_letter``, and
+    ``internal_memo``: each exposes ``approval_signature_request_id``
+    (falsy without an active signature request), and no signature
+    request is created when the approval template has no Documenso
+    signing template configured.
+    """
+
     def test_letter_documenso_signing_approval(self):
+        """Run the Documenso signing approval scenario for all three models."""
         self.run_yaml_scenario("test_data_letter_documenso_signing_approval.yaml")


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring class & method yang hilang di `ssi_letter_documenso_signing`,
temuan sapuan kepatuhan validator `module` v3.10.0 dan `unit-test` v0.10.3.

- Docstring class `OutgoingLetter`, `IncomingLetter`, `InternalMemo` di `models/`
  yang menjelaskan apa yang ditambahkan modul glue ini pada masing-masing model.
- Docstring class test `TestLetterDocumensoSigningApproval` dan method
  `test_letter_documenso_signing_approval` di `tests/`.

Tidak ada perubahan perilaku, penamaan, atau tanda tangan method apa pun.

## Verifikasi

```
#VALIDATOR name=module    target=ssi_letter_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_letter_documenso_signing series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-letter modules=1 failed=0 skipped=0 status=OK
```

Closes #16