### PR TITLE
[UPD] ssi_letter - Ganti invalidate_cache manual dengan auto_refresh

### DIFF
--- a/ssi_letter/tests/test_data_incoming_letter.yaml
+++ b/ssi_letter/tests/test_data_incoming_letter.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Incoming Letter - Full Workflow: draft to done"
     steps:
@@ -46,11 +49,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "letter"
-        method: "invalidate_cache"
-
       - step: "Approve incoming letter"
         action: "call"
         target: "letter"
@@ -95,11 +93,6 @@ scenarios:
         target: "letter"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "letter"
-        method: "invalidate_cache"
 
       - step: "Restart incoming letter"
         action: "call"

--- a/ssi_letter/tests/test_data_internal_memo.yaml
+++ b/ssi_letter/tests/test_data_internal_memo.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Internal Memo - Full Workflow: draft to done"
     steps:
@@ -38,11 +41,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "memo"
-        method: "invalidate_cache"
-
       - step: "Approve internal memo"
         action: "call"
         target: "memo"
@@ -79,11 +77,6 @@ scenarios:
         target: "memo"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "memo"
-        method: "invalidate_cache"
 
       - step: "Restart internal memo"
         action: "call"

--- a/ssi_letter/tests/test_data_outgoing_letter.yaml
+++ b/ssi_letter/tests/test_data_outgoing_letter.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Outgoing Letter - Full Workflow: draft to open to done"
     steps:
@@ -46,11 +49,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "letter"
-        method: "invalidate_cache"
-
       - step: "Approve outgoing letter"
         action: "call"
         target: "letter"
@@ -60,11 +58,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate cache after approve"
-        action: "call"
-        target: "letter"
-        method: "invalidate_cache"
 
       - step: "Mark outgoing letter as done"
         action: "call"
@@ -112,11 +105,6 @@ scenarios:
         target: "letter"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "letter"
-        method: "invalidate_cache"
 
       - step: "Restart outgoing letter"
         action: "call"


### PR DESCRIPTION
## Ringkasan

Mengganti step `action: call` / `method: "invalidate_cache"` manual dengan opsi
`auto_refresh: true` di tingkat berkas (`options:`) pada ketiga berkas skenario
unit test `ssi_letter`:

- `tests/test_data_incoming_letter.yaml` (2 step dihapus)
- `tests/test_data_internal_memo.yaml` (2 step dihapus)
- `tests/test_data_outgoing_letter.yaml` (3 step dihapus)

`invalidate_cache` adalah method ORM Odoo yang deprecated sejak 16.0 dan **dihapus di
17.0**, sehingga skenario ini sebelumnya version-coupled. `auto_refresh` memanggil API
cache yang benar per-seri lewat pustaka `odoo-yaml-test`, sehingga YAML-nya tetap
identik lintas versi.

Jumlah skenario, urutan skenario, dan jumlah assert pada ketiga berkas **tidak
berubah** — hanya ketujuh step invalidate_cache manual yang dihapus.

## Referensi

Closes #15

## Test

Seluruh skenario dijalankan di CI GitHub (bukan lokal, sesuai instruksi).