### PR TITLE
[UPD] ssi_letter_operating_unit - Lengkapi docstring

### DIFF
--- a/ssi_letter_operating_unit/models/incoming_letter.py
+++ b/ssi_letter_operating_unit/models/incoming_letter.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class IncomingLetter(models.Model):
+    """
+    Adds Operating Unit ownership to incoming letter documents.
+    Restricts each incoming letter to a single operating unit via
+    ``mixin.single_operating_unit``, enabling operating unit based
+    visibility and security rules for the document.
+    """
+
     _name = "incoming_letter"
     _inherit = [
         "incoming_letter",

--- a/ssi_letter_operating_unit/models/outgoing_letter.py
+++ b/ssi_letter_operating_unit/models/outgoing_letter.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class OutgoingLetter(models.Model):
+    """
+    Adds Operating Unit ownership to outgoing letter documents.
+    Restricts each outgoing letter to a single operating unit via
+    ``mixin.single_operating_unit``, enabling operating unit based
+    visibility and security rules for the document.
+    """
+
     _name = "outgoing_letter"
     _inherit = [
         "outgoing_letter",

--- a/ssi_letter_operating_unit/tests/test_letter_operating_unit.py
+++ b/ssi_letter_operating_unit/tests/test_letter_operating_unit.py
@@ -9,5 +9,14 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestLetterOperatingUnit(YamlTransactionCase):
+    """Test Operating Unit support on letter and memo documents.
+
+    Covers ``outgoing_letter``, ``incoming_letter``, and
+    ``internal_memo`` records created by
+    ``ssi_letter_operating_unit``, asserting each carries an
+    operating unit after creation.
+    """
+
     def test_letter_operating_unit(self):
+        """Run the Operating Unit scenarios for letter documents."""
         self.run_yaml_scenario("test_data_letter_operating_unit.yaml")


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring pada setiap class & method di `models/incoming_letter.py`,
`models/outgoing_letter.py`, serta class test dan method `test_*` di
`tests/test_letter_operating_unit.py` pada modul `ssi_letter_operating_unit`,
mengikuti format baku SSI (bahasa Inggris, gaya reST, ≤ 79 karakter/baris).

- Docstring class `IncomingLetter` dan `OutgoingLetter` menyatakan apa yang
  ditambahkan modul glue ini (keterikatan dokumen pada operating unit),
  bukan mengulang tujuan model asli.
- Docstring class test dan method `test_letter_operating_unit` menyatakan
  skenario yang diuji.
- Tidak ada perubahan nama class, method, atau field.

Menyelesaikan temuan sapuan kepatuhan validator `module` v3.10.0 berkunci
`setiap-class-method-punya-docstring` dan validator `unit-test` v0.10.3
berkunci `setiap-class-method-test-punya-docstring`.

Closes #17

## Test plan

- [x] `verify-module.sh ssi_letter_operating_unit 14.0` → LOLOS: 0 ERROR
- [x] `validate-unit-test.sh ssi_letter_operating_unit 14.0` → LOLOS: 0 ERROR
- [x] `pre-commit-gate.sh` → GATE OK (6 pemeriksaan, 0 pelanggaran baru)
- [ ] CI GitHub Actions hijau

🤖 Generated with [Claude Code](https://claude.com/claude-code)