### PR TITLE
[UPD] ssi_letter_work_log - Lengkapi docstring

### DIFF
--- a/ssi_letter_work_log/models/incoming_letter.py
+++ b/ssi_letter_work_log/models/incoming_letter.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class IncomingLetter(models.Model):
+    """
+    Enables work hour logging on incoming letter documents.
+
+    Adds the ``mixin.work_object`` capability to ``incoming_letter`` so
+    users can record work log entries (``hr.work_log``) against a
+    letter, track estimated vs. realized work, and link entries to an
+    analytic account.
+    """
+
     _name = "incoming_letter"
     _inherit = [
         "incoming_letter",

--- a/ssi_letter_work_log/models/internal_memo.py
+++ b/ssi_letter_work_log/models/internal_memo.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class InternalMemo(models.Model):
+    """
+    Enables work hour logging on internal memo documents.
+
+    Adds the ``mixin.work_object`` capability to ``internal_memo`` so
+    users can record work log entries (``hr.work_log``) against a
+    memo, track estimated vs. realized work, and link entries to an
+    analytic account.
+    """
+
     _name = "internal_memo"
     _inherit = [
         "internal_memo",

--- a/ssi_letter_work_log/models/outgoing_letter.py
+++ b/ssi_letter_work_log/models/outgoing_letter.py
@@ -6,6 +6,15 @@ from odoo import models
 
 
 class OutgoingLetter(models.Model):
+    """
+    Enables work hour logging on outgoing letter documents.
+
+    Adds the ``mixin.work_object`` capability to ``outgoing_letter`` so
+    users can record work log entries (``hr.work_log``) against a
+    letter, track estimated vs. realized work, and link entries to an
+    analytic account.
+    """
+
     _name = "outgoing_letter"
     _inherit = [
         "outgoing_letter",

--- a/ssi_letter_work_log/tests/test_letter_work_log.py
+++ b/ssi_letter_work_log/tests/test_letter_work_log.py
@@ -9,5 +9,14 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestLetterWorkLog(YamlTransactionCase):
+    """
+    Test work log field exposure on incoming/outgoing letter and memo.
+
+    Covers ``outgoing_letter``, ``incoming_letter``, and
+    ``internal_memo``, asserting each exposes an empty
+    ``work_log_ids`` field by default after creation.
+    """
+
     def test_letter_work_log(self):
+        """Run the work log scenarios for letter and memo documents."""
         self.run_yaml_scenario("test_data_letter_work_log.yaml")


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring class dan method pada modul `ssi_letter_work_log` sesuai standar
SSI (`10-docstring.md`): bahasa Inggris, gaya reST, ≤79 karakter per baris.

- Docstring class `IncomingLetter`, `InternalMemo`, `OutgoingLetter` di `models/` —
  menyatakan penambahan pencatatan jam kerja (work log) pada dokumen, bukan mengulang
  tujuan model asli.
- Docstring class test `TestLetterWorkLog` dan method `test_letter_work_log` di
  `tests/test_letter_work_log.py` — menyebutkan skenario yang diuji.

Tidak ada perubahan perilaku, penamaan, atau tanda tangan method apa pun.

## Verifikasi

`pre-commit-gate.sh` (keenam validator × modul tersentuh):

```
#GATE repo=ssi-letter modules=1 failed=0 skipped=0 status=OK
```

Closes #18