### PR TITLE
[UPD] ssi_letter_operating_unit - Tulis IK delta & tour

### DIFF
--- a/ssi_letter_operating_unit/README.rst
+++ b/ssi_letter_operating_unit/README.rst
@@ -7,6 +7,13 @@ Letter Management + Operating Unit Integration
 ==============================================
 
 
+Work Instruction
+================
+
+* `Create Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Create Incoming Letter <docs/incoming_letter/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_letter_operating_unit/__manifest__.py
+++ b/ssi_letter_operating_unit/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2024 OpenSynergy Indonesia
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
+# pylint: disable=C8101
 {
     "name": "Letter Management + Operating Unit Integration",
     "version": "14.0.1.3.1",
@@ -12,6 +13,7 @@
     "depends": [
         "ssi_letter",
         "ssi_operating_unit_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_group/outgoing_letter.xml",
@@ -23,6 +25,7 @@
         "views/outgoing_letter_views.xml",
         "views/incoming_letter_views.xml",
         "views/internal_memo_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
     "images": [],

--- a/ssi_letter_operating_unit/docs/incoming_letter/01-create.md
+++ b/ssi_letter_operating_unit/docs/incoming_letter/01-create.md
@@ -1,0 +1,24 @@
+# Create Incoming Letter
+
+> **Module:** ssi_letter_operating_unit
+>
+> **Extends:** ssi_letter — model `incoming_letter`, aksi `01-create`
+
+## Additional Pre-Condition
+
+- **Config:** Group `operating_unit.group_multi_operating_unit` is active — the
+  **Operating Unit** field described below is only visible when this group is enabled.
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: The operating unit that owns this letter. Automatically filled
+  from the current user's default operating unit. Change if needed. Visible only when
+  group `operating_unit.group_multi_operating_unit` is active.
+
+## Modified — Record Visibility
+
+- The Incoming Letters list is filtered by operating unit (record rule
+  `incoming_letter_rule_ou`). A user only sees letters whose **Operating Unit** is one
+  of the operating units assigned to them. This is not a Flow step.

--- a/ssi_letter_operating_unit/docs/outgoing_letter/01-create.md
+++ b/ssi_letter_operating_unit/docs/outgoing_letter/01-create.md
@@ -1,0 +1,24 @@
+# Create Outgoing Letter
+
+> **Module:** ssi_letter_operating_unit
+>
+> **Extends:** ssi_letter — model `outgoing_letter`, aksi `01-create`
+
+## Additional Pre-Condition
+
+- **Config:** Group `operating_unit.group_multi_operating_unit` is active — the
+  **Operating Unit** field described below is only visible when this group is enabled.
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: The operating unit that owns this letter. Automatically filled
+  from the current user's default operating unit. Change if needed. Visible only when
+  group `operating_unit.group_multi_operating_unit` is active.
+
+## Modified — Record Visibility
+
+- The Outgoing Letters list is filtered by operating unit (record rule
+  `outgoing_letter_rule_ou`). A user only sees letters whose **Operating Unit** is one
+  of the operating units assigned to them. This is not a Flow step.

--- a/ssi_letter_operating_unit/static/tests/tours/incoming_letter_tour.js
+++ b/ssi_letter_operating_unit/static/tests/tours/incoming_letter_tour.js
@@ -1,0 +1,74 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_operating_unit.incoming_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/incoming_letter/01-create.md (E1 delta -- Additional Fields)
+    // Navigation (open menu -> New) is taken from the base IK
+    // ssi_letter/docs/incoming_letter/01-create.md Flow steps 1-2 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §1 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion
+    // comes from this module's own IK: the Operating Unit field is visible
+    // on the create form for a user in the
+    // operating_unit.group_multi_operating_unit group. The tour stops
+    // there; it does not fill, save, or confirm (E1 delta-only).
+    tour.register(
+        "ssi_letter_operating_unit_incoming_letter_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Incoming Letters menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Incoming Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.incoming_letter_menu"]',
+            },
+            {
+                content: "Incoming Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Incoming Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Click the New button. (14.0: "Create")
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Delta assertion — the Operating Unit field is visible on
+            // the create form for a user in the multi operating unit
+            // group. The tour stops here (E1 delta-only).
+            {
+                content: "Operating Unit field is visible on the form",
+                trigger:
+                    ".o_form_view.o_form_editable .o_field_widget[name='operating_unit_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_operating_unit/static/tests/tours/outgoing_letter_tour.js
+++ b/ssi_letter_operating_unit/static/tests/tours/outgoing_letter_tour.js
@@ -1,0 +1,74 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_operating_unit.outgoing_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/outgoing_letter/01-create.md (E1 delta -- Additional Fields)
+    // Navigation (open menu -> New) is taken from the base IK
+    // ssi_letter/docs/outgoing_letter/01-create.md Flow steps 1-2 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §1 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion
+    // comes from this module's own IK: the Operating Unit field is visible
+    // on the create form for a user in the
+    // operating_unit.group_multi_operating_unit group. The tour stops
+    // there; it does not fill, save, or confirm (E1 delta-only).
+    tour.register(
+        "ssi_letter_operating_unit_outgoing_letter_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Outgoing Letters menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Outgoing Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.outgoing_letter_menu"]',
+            },
+            {
+                content: "Outgoing Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Outgoing Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Click the New button. (14.0: "Create")
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Delta assertion — the Operating Unit field is visible on
+            // the create form for a user in the multi operating unit
+            // group. The tour stops here (E1 delta-only).
+            {
+                content: "Operating Unit field is visible on the form",
+                trigger:
+                    ".o_form_view.o_form_editable .o_field_widget[name='operating_unit_id']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_operating_unit/tests/__init__.py
+++ b/ssi_letter_operating_unit/tests/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_letter_operating_unit  # noqa: F401
+from . import test_ui_outgoing_letter  # noqa: F401
+from . import test_ui_incoming_letter  # noqa: F401

--- a/ssi_letter_operating_unit/tests/test_ui_incoming_letter.py
+++ b/ssi_letter_operating_unit/tests/test_ui_incoming_letter.py
@@ -1,0 +1,57 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiIncomingLetter(HttpSavepointCase):
+    """Tour test for the create-time Operating Unit field."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant ``admin`` the multi operating unit group.
+
+        Pre-Condition IK: the Operating Unit field is gated by
+        ``groups="operating_unit.group_multi_operating_unit"`` in the
+        form view -- without membership, the field is never rendered
+        and the delta assertion would never find it. ``admin`` also
+        needs at least one operating unit assigned so the field has a
+        meaningful (non-empty) allowed set.
+        """
+        super().setUpClass()
+        cls.user_admin = cls.env.ref("base.user_admin")
+        operating_unit_partner = cls.env["res.partner"].create(
+            {"name": "Tour IL OU Partner"}
+        )
+        cls.operating_unit = cls.env["operating.unit"].create(
+            {
+                "name": "Tour IL Operating Unit",
+                "code": "TILOU",
+                "partner_id": operating_unit_partner.id,
+            }
+        )
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.user_admin.id)]}
+        )
+        cls.user_admin.sudo().write(
+            {
+                "assigned_operating_unit_ids": [(4, cls.operating_unit.id)],
+                "default_operating_unit_id": cls.operating_unit.id,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/01-create.md (E1 delta -- Additional
+        Fields)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_operating_unit_incoming_letter_create",
+            login="admin",
+        )

--- a/ssi_letter_operating_unit/tests/test_ui_outgoing_letter.py
+++ b/ssi_letter_operating_unit/tests/test_ui_outgoing_letter.py
@@ -1,0 +1,57 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiOutgoingLetter(HttpSavepointCase):
+    """Tour test for the create-time Operating Unit field."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant ``admin`` the multi operating unit group.
+
+        Pre-Condition IK: the Operating Unit field is gated by
+        ``groups="operating_unit.group_multi_operating_unit"`` in the
+        form view -- without membership, the field is never rendered
+        and the delta assertion would never find it. ``admin`` also
+        needs at least one operating unit assigned so the field has a
+        meaningful (non-empty) allowed set.
+        """
+        super().setUpClass()
+        cls.user_admin = cls.env.ref("base.user_admin")
+        operating_unit_partner = cls.env["res.partner"].create(
+            {"name": "Tour OL OU Partner"}
+        )
+        cls.operating_unit = cls.env["operating.unit"].create(
+            {
+                "name": "Tour OL Operating Unit",
+                "code": "TOLOU",
+                "partner_id": operating_unit_partner.id,
+            }
+        )
+        cls.env.ref("operating_unit.group_multi_operating_unit").sudo().write(
+            {"users": [(4, cls.user_admin.id)]}
+        )
+        cls.user_admin.sudo().write(
+            {
+                "assigned_operating_unit_ids": [(4, cls.operating_unit.id)],
+                "default_operating_unit_id": cls.operating_unit.id,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/01-create.md (E1 delta -- Additional
+        Fields)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_operating_unit_outgoing_letter_create",
+            login="admin",
+        )

--- a/ssi_letter_operating_unit/views/assets.xml
+++ b/ssi_letter_operating_unit/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_letter_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_letter_operating_unit/static/tests/tours/outgoing_letter_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_letter_operating_unit/static/tests/tours/incoming_letter_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan direktori `docs/` pada `ssi_letter_operating_unit` berisi IK delta untuk
`outgoing_letter` dan `incoming_letter` yang mendokumentasikan field `operating_unit_id`
(arketipe E1) dan penyaringan visibilitas per operating unit lewat record rule
(arketipe E6), beserta tour delta pasangan berkas IK E1.

- IK delta `docs/outgoing_letter/01-create.md` dan `docs/incoming_letter/01-create.md`:
  section `## Additional Fields` (field `operating_unit_id`, digrup
  `operating_unit.group_multi_operating_unit`) dan `## Modified — Record Visibility`
  (penyaringan daftar dokumen per operating unit lewat `ir.rule`).
- Tour delta `ssi_letter_operating_unit_outgoing_letter_create` dan
  `ssi_letter_operating_unit_incoming_letter_create`: memastikan field Operating Unit
  muncul di form create saat grup multi operating unit aktif, lalu berhenti (E1
  delta-only — tidak melanjutkan ke save/confirm).
- Registrasi asset `web.assets_tests` (`views/assets.xml`) dan berkas `HttpCase`
  (`tests/test_ui_outgoing_letter.py`, `tests/test_ui_incoming_letter.py`).
- README.rst mendapat section `Work Instruction`.
- Tidak ada perubahan pada `models/`, `views/outgoing_letter_views.xml`,
  `views/incoming_letter_views.xml`, atau `security/` — murni dokumentasi + tour.

## Validator

```
#VALIDATOR name=module target=ssi_letter_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik target=ssi_letter_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=ssi_letter_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-letter modules=1 failed=0 skipped=0 status=OK
```

Closes #19