### PR TITLE
[UPD] ssi_letter_documenso_signing - Tulis IK delta & tour

### DIFF
--- a/ssi_letter_documenso_signing/README.rst
+++ b/ssi_letter_documenso_signing/README.rst
@@ -7,6 +7,14 @@ Letter Management - Documenso Signing Integration
 =====================================================
 
 
+Work Instruction
+================
+
+* `Approve Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Approve Incoming Letter <docs/incoming_letter/index.html>`_
+* `Approve Internal Memo <docs/internal_memo/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_letter_documenso_signing/__manifest__.py
+++ b/ssi_letter_documenso_signing/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_letter",
         "ssi_connector_documenso_signing",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
     "contributors": [

--- a/ssi_letter_documenso_signing/docs/incoming_letter/05-approve.md
+++ b/ssi_letter_documenso_signing/docs/incoming_letter/05-approve.md
@@ -1,0 +1,33 @@
+# Approve Incoming Letter
+
+> **Module:** ssi_letter_documenso_signing
+>
+> **Extends:** ssi_letter — model `incoming_letter`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: on Flow base step 3 (Click the **Approve** button). This module adds a
+  **Signature Requests** page to the form (present from record creation onward, inserted
+  after the last existing tab), showing the **Approval Signature Request** field
+  (`approval_signature_request_id`) plus the record's full signing history.
+- When the matching `approval.template` has a Documenso signing template configured,
+  Confirm (base `04-confirm.md`) already created a single `documenso.signature.request`
+  instead of a per-level approval record, and it is shown in that field. From this point
+  in the base Flow, the manual Approve click described above does not apply to this
+  document: there is no `approval.approval` record for the pending level, so there is
+  nothing to click Approve on for it. Approval is granted automatically once the linked
+  signature request reaches the **Signed** state in Documenso.
+- If the signature request is cancelled instead (e.g. a signer declines in Documenso),
+  this document moves straight to **Rejected** — the same outcome as clicking Reject in
+  the base Flow (`06-reject.md`), but triggered by Documenso instead of by a user
+  action.
+- When the approval template has **no** Documenso signing template configured, the base
+  Flow above applies unchanged; the **Signature Requests** page is still visible but its
+  **Approval Signature Request** field stays empty.
+
+## Additional Post-Condition
+
+- Once the signature request reaches **Signed**, this document completes exactly as
+  described in the base Post-Condition: since a Documenso-configured template has a
+  single approval level, this document is automatically finished — status changes
+  straight to **Done** — and the document number is generated automatically.

--- a/ssi_letter_documenso_signing/docs/internal_memo/05-approve.md
+++ b/ssi_letter_documenso_signing/docs/internal_memo/05-approve.md
@@ -1,0 +1,33 @@
+# Approve Internal Memo
+
+> **Module:** ssi_letter_documenso_signing
+>
+> **Extends:** ssi_letter — model `internal_memo`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: on Flow base step 3 (Click the **Approve** button). This module adds a
+  **Signature Requests** page to the form (present from record creation onward, inserted
+  after the last existing tab), showing the **Approval Signature Request** field
+  (`approval_signature_request_id`) plus the record's full signing history.
+- When the matching `approval.template` has a Documenso signing template configured,
+  Confirm (base `04-confirm.md`) already created a single `documenso.signature.request`
+  instead of a per-level approval record, and it is shown in that field. From this point
+  in the base Flow, the manual Approve click described above does not apply to this
+  document: there is no `approval.approval` record for the pending level, so there is
+  nothing to click Approve on for it. Approval is granted automatically once the linked
+  signature request reaches the **Signed** state in Documenso.
+- If the signature request is cancelled instead (e.g. a signer declines in Documenso),
+  this document moves straight to **Rejected** — the same outcome as clicking Reject in
+  the base Flow (`06-reject.md`), but triggered by Documenso instead of by a user
+  action.
+- When the approval template has **no** Documenso signing template configured, the base
+  Flow above applies unchanged; the **Signature Requests** page is still visible but its
+  **Approval Signature Request** field stays empty.
+
+## Additional Post-Condition
+
+- Once the signature request reaches **Signed**, this document completes exactly as
+  described in the base Post-Condition: since a Documenso-configured template has a
+  single approval level, this document is automatically finished — status changes
+  straight to **Done** — and the document number is generated automatically.

--- a/ssi_letter_documenso_signing/docs/outgoing_letter/05-approve.md
+++ b/ssi_letter_documenso_signing/docs/outgoing_letter/05-approve.md
@@ -1,0 +1,33 @@
+# Approve Outgoing Letter
+
+> **Module:** ssi_letter_documenso_signing
+>
+> **Extends:** ssi_letter — model `outgoing_letter`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: on Flow base step 3 (Click the **Approve** button). This module adds a
+  **Signature Requests** page to the form (present from record creation onward, inserted
+  after the last existing tab), showing the **Approval Signature Request** field
+  (`approval_signature_request_id`) plus the record's full signing history.
+- When the matching `approval.template` has a Documenso signing template configured,
+  Confirm (base `04-confirm.md`) already created a single `documenso.signature.request`
+  instead of a per-level approval record, and it is shown in that field. From this point
+  in the base Flow, the manual Approve click described above does not apply to this
+  document: there is no `approval.approval` record for the pending level, so there is
+  nothing to click Approve on for it. Approval is granted automatically once the linked
+  signature request reaches the **Signed** state in Documenso.
+- If the signature request is cancelled instead (e.g. a signer declines in Documenso),
+  this document moves straight to **Rejected** — the same outcome as clicking Reject in
+  the base Flow (`06-reject.md`), but triggered by Documenso instead of by a user
+  action.
+- When the approval template has **no** Documenso signing template configured, the base
+  Flow above applies unchanged; the **Signature Requests** page is still visible but its
+  **Approval Signature Request** field stays empty.
+
+## Additional Post-Condition
+
+- Once the signature request reaches **Signed**, this document completes exactly as
+  described in the base Post-Condition: since a Documenso-configured template has a
+  single approval level, status changes straight to **On Progress** and the document
+  number is generated automatically.

--- a/ssi_letter_documenso_signing/static/tests/tours/incoming_letter_tour.js
+++ b/ssi_letter_documenso_signing/static/tests/tours/incoming_letter_tour.js
@@ -1,0 +1,111 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_documenso_signing.incoming_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/incoming_letter/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record -> click Approve -> confirm the
+    // dialog) is retraced from the base IK
+    // ssi_letter/docs/incoming_letter/05-approve.md Flow steps 1-4 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion,
+    // inserted right before the base's Flow step 3, proves the additional
+    // "Signature Requests" page is visible on the form. The approval
+    // template used by this fixture has no Documenso signing template
+    // configured (out of scope -- Ruang Lingkup excludes configuring the
+    // Documenso connector), so the base Approve click still completes the
+    // document normally; that final state assertion proves the action
+    // still finishes end to end with the new page in place.
+    tour.register(
+        "ssi_letter_documenso_signing_incoming_letter_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Incoming Letters menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Incoming Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.incoming_letter_menu"]',
+            },
+            {
+                content: "Incoming Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Incoming Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-DS-IL-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Delta anchor — before clicking Approve (base Flow step 3),
+            // open the Signature Requests page this module adds and prove
+            // it is rendered.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored to the group label, not the (empty) many2one
+                // field -- a readonly field without a value renders as a
+                // zero-pixel element and never becomes a visible trigger
+                // (odoo-development-ui-test skill, patterns.md §O).
+                content:
+                    "Signature Requests page shows the Approval Signing Request group",
+                trigger: ".o_horizontal_separator:contains(Approval Signing Request)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Base Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // ── Base Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // ── Additional Post-Condition — the action still completes:
+            // this document is automatically finished, same as the base
+            // Post-Condition.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_documenso_signing/static/tests/tours/internal_memo_tour.js
+++ b/ssi_letter_documenso_signing/static/tests/tours/internal_memo_tour.js
@@ -1,0 +1,111 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_documenso_signing.internal_memo_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/internal_memo/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record -> click Approve -> confirm the
+    // dialog) is retraced from the base IK
+    // ssi_letter/docs/internal_memo/05-approve.md Flow steps 1-4 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion,
+    // inserted right before the base's Flow step 3, proves the additional
+    // "Signature Requests" page is visible on the form. The approval
+    // template used by this fixture has no Documenso signing template
+    // configured (out of scope -- Ruang Lingkup excludes configuring the
+    // Documenso connector), so the base Approve click still completes the
+    // document normally; that final state assertion proves the action
+    // still finishes end to end with the new page in place.
+    tour.register(
+        "ssi_letter_documenso_signing_internal_memo_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Internal Memos menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Internal Memos menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_menu"]',
+            },
+            {
+                content: "Internal Memo list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-DS-IM-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Delta anchor — before clicking Approve (base Flow step 3),
+            // open the Signature Requests page this module adds and prove
+            // it is rendered.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored to the group label, not the (empty) many2one
+                // field -- a readonly field without a value renders as a
+                // zero-pixel element and never becomes a visible trigger
+                // (odoo-development-ui-test skill, patterns.md §O).
+                content:
+                    "Signature Requests page shows the Approval Signing Request group",
+                trigger: ".o_horizontal_separator:contains(Approval Signing Request)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Base Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // ── Base Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // ── Additional Post-Condition — the action still completes:
+            // this document is automatically finished, same as the base
+            // Post-Condition.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_documenso_signing/static/tests/tours/outgoing_letter_tour.js
+++ b/ssi_letter_documenso_signing/static/tests/tours/outgoing_letter_tour.js
@@ -1,0 +1,111 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_documenso_signing.outgoing_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/outgoing_letter/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record -> click Approve -> confirm the
+    // dialog) is retraced from the base IK
+    // ssi_letter/docs/outgoing_letter/05-approve.md Flow steps 1-4 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion,
+    // inserted right before the base's Flow step 3, proves the additional
+    // "Signature Requests" page is visible on the form. The approval
+    // template used by this fixture has no Documenso signing template
+    // configured (out of scope -- Ruang Lingkup excludes configuring the
+    // Documenso connector), so the base Approve click still completes the
+    // document normally; that final state assertion proves the action
+    // still finishes end to end with the new page in place.
+    tour.register(
+        "ssi_letter_documenso_signing_outgoing_letter_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Outgoing Letters menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Outgoing Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.outgoing_letter_menu"]',
+            },
+            {
+                content: "Outgoing Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Outgoing Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-DS-OL-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Delta anchor — before clicking Approve (base Flow step 3),
+            // open the Signature Requests page this module adds and prove
+            // it is rendered.
+            {
+                content: "Open the Signature Requests tab",
+                trigger: ".o_notebook .nav-link:contains(Signature Requests)",
+            },
+            {
+                // Anchored to the group label, not the (empty) many2one
+                // field -- a readonly field without a value renders as a
+                // zero-pixel element and never becomes a visible trigger
+                // (odoo-development-ui-test skill, patterns.md §O).
+                content:
+                    "Signature Requests page shows the Approval Signing Request group",
+                trigger: ".o_horizontal_separator:contains(Approval Signing Request)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Base Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // ── Base Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // ── Additional Post-Condition — the action still completes:
+            // status jumps straight to On Progress, same as the base
+            // Post-Condition.
+            {
+                content: "Status is On Progress",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_documenso_signing/tests/__init__.py
+++ b/ssi_letter_documenso_signing/tests/__init__.py
@@ -3,3 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
 
 from . import test_letter_documenso_signing_approval  # noqa: F401
+from . import test_ui_outgoing_letter  # noqa: F401
+from . import test_ui_incoming_letter  # noqa: F401
+from . import test_ui_internal_memo  # noqa: F401

--- a/ssi_letter_documenso_signing/tests/test_ui_incoming_letter.py
+++ b/ssi_letter_documenso_signing/tests/test_ui_incoming_letter.py
@@ -1,0 +1,73 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiIncomingLetter(HttpSavepointCase):
+    """Tour test for the Documenso Signature Requests page on Approve."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create one confirmed ``incoming_letter`` fixture for the tour.
+
+        ``incoming_letter_validator_group`` already grants
+        ``base.user_admin`` membership by default (see
+        ``ssi_letter``'s ``security/res_groups/incoming_letter.xml``), so
+        ``admin`` can both open and approve the fixture without any extra
+        group setup. The record's ``user_id`` is set explicitly to
+        ``admin`` — ``cls.env`` runs as SUPERUSER here, and the record
+        rule ``incoming_letter_internal_user_rule`` would otherwise hide
+        it from the ``admin`` tour session.
+
+        No ``approval.template`` with a Documenso signing template is
+        configured here — that is server-side Documenso connector setup,
+        out of scope for this module's IK/tour (Ruang Lingkup). The
+        shipped "Standard" template therefore drives approval normally,
+        and the tour proves the added Signature Requests page renders
+        alongside that unchanged base flow.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        company_partner = cls.env.company.partner_id
+        partner = cls.env["res.partner"].create(
+            {"name": "TOUR DS IL Partner", "is_company": True}
+        )
+        letter_type = cls.env["letter_type"].create(
+            {"name": "TOUR DS IL Type", "code": "/"}
+        )
+        internal_partner = cls.env["res.partner"].create(
+            {
+                "name": "TOUR-DS-IL-APPROVE",
+                "parent_id": company_partner.id,
+                "is_company": False,
+            }
+        )
+        cls.rec_approve = cls.env["incoming_letter"].create(
+            {
+                "partner_id": partner.id,
+                "internal_partner_id": internal_partner.id,
+                "type_id": letter_type.id,
+                "date": "2026-01-15",
+                "title": "TOUR DS Incoming Letter Approve",
+                "digital": True,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+    def test_approve(self):
+        """Run the approve tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_documenso_signing_incoming_letter_approve",
+            login="admin",
+        )

--- a/ssi_letter_documenso_signing/tests/test_ui_internal_memo.py
+++ b/ssi_letter_documenso_signing/tests/test_ui_internal_memo.py
@@ -1,0 +1,60 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiInternalMemo(HttpSavepointCase):
+    """Tour test for the Documenso Signature Requests page on Approve."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create one confirmed ``internal_memo`` fixture for the tour.
+
+        ``internal_memo_validator_group`` already grants
+        ``base.user_admin`` membership by default (see
+        ``ssi_letter``'s ``security/res_groups/internal_memo.xml``), so
+        ``admin`` can both open and approve the fixture without any extra
+        group setup. The record's ``user_id`` is set explicitly to
+        ``admin`` — ``cls.env`` runs as SUPERUSER here, and the record
+        rule ``internal_memo_internal_user_rule`` would otherwise hide it
+        from the ``admin`` tour session.
+
+        No ``approval.template`` with a Documenso signing template is
+        configured here — that is server-side Documenso connector setup,
+        out of scope for this module's IK/tour (Ruang Lingkup). The
+        shipped "Standard" template therefore drives approval normally,
+        and the tour proves the added Signature Requests page renders
+        alongside that unchanged base flow.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        memo_type = cls.env["internal_memo_type"].create(
+            {"name": "TOUR DS IM Type", "code": "/"}
+        )
+        cls.rec_approve = cls.env["internal_memo"].create(
+            {
+                "type_id": memo_type.id,
+                "date": "2026-01-15",
+                "title": "TOUR-DS-IM-APPROVE",
+                "memo": "<p>TOUR DS Internal Memo body content.</p>",
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+    def test_approve(self):
+        """Run the approve tour for ``internal_memo``.
+
+        IK: docs/internal_memo/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_documenso_signing_internal_memo_approve",
+            login="admin",
+        )

--- a/ssi_letter_documenso_signing/tests/test_ui_outgoing_letter.py
+++ b/ssi_letter_documenso_signing/tests/test_ui_outgoing_letter.py
@@ -1,0 +1,73 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiOutgoingLetter(HttpSavepointCase):
+    """Tour test for the Documenso Signature Requests page on Approve."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create one confirmed ``outgoing_letter`` fixture for the tour.
+
+        ``outgoing_letter_validator_group`` already grants
+        ``base.user_admin`` membership by default (see
+        ``ssi_letter``'s ``security/res_groups/outgoing_letter.xml``), so
+        ``admin`` can both open and approve the fixture without any extra
+        group setup. The record's ``user_id`` is set explicitly to
+        ``admin`` — ``cls.env`` runs as SUPERUSER here, and the record
+        rule ``outgoing_letter_internal_user_rule`` would otherwise hide
+        it from the ``admin`` tour session.
+
+        No ``approval.template`` with a Documenso signing template is
+        configured here — that is server-side Documenso connector setup,
+        out of scope for this module's IK/tour (Ruang Lingkup). The
+        shipped "Standard" template therefore drives approval normally,
+        and the tour proves the added Signature Requests page renders
+        alongside that unchanged base flow.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        company_partner = cls.env.company.partner_id
+        partner = cls.env["res.partner"].create(
+            {"name": "TOUR DS OL Partner", "is_company": True}
+        )
+        letter_type = cls.env["letter_type"].create(
+            {"name": "TOUR DS OL Type", "code": "/"}
+        )
+        internal_partner = cls.env["res.partner"].create(
+            {
+                "name": "TOUR-DS-OL-APPROVE",
+                "parent_id": company_partner.id,
+                "is_company": False,
+            }
+        )
+        cls.rec_approve = cls.env["outgoing_letter"].create(
+            {
+                "partner_id": partner.id,
+                "internal_partner_id": internal_partner.id,
+                "type_id": letter_type.id,
+                "date": "2026-01-15",
+                "title": "TOUR DS Outgoing Letter Approve",
+                "digital": True,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+    def test_approve(self):
+        """Run the approve tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_documenso_signing_outgoing_letter_approve",
+            login="admin",
+        )

--- a/ssi_letter_documenso_signing/views/assets.xml
+++ b/ssi_letter_documenso_signing/views/assets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_letter_documenso_signing assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_letter_documenso_signing/static/tests/tours/outgoing_letter_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_letter_documenso_signing/static/tests/tours/incoming_letter_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_letter_documenso_signing/static/tests/tours/internal_memo_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menutup utang IK yang ditandai sapuan kepatuhan 14.0 (validator `ik`) pada
`ssi_letter_documenso_signing`: modul ini menyisipkan
`mixin.documenso_signing_approval` dan menyalakan
`_documenso_signing_create_page = True` pada `outgoing_letter`,
`incoming_letter`, dan `internal_memo`, menambahkan tab **Signature Requests**
ke form dan mengalihkan mekanisme approval ke `documenso.signature.request`
saat approval template-nya dikonfigurasi untuk itu.

* Tambah IK delta bersection `## Modified Flow` (arketipe **E2a**) untuk
  aksi Approve (`05-approve.md`) ketiga model, masing-masing menyebut anchor
  Flow base (`Click the Approve button`, langkah 3) dan blok metadata
  `Module:`/`Extends:`.
* Tambah tour delta pasangan per model, menelusuri ulang navigasi base
  (buka menu → buka record → Approve → konfirmasi dialog), dengan assertion
  tambahan bahwa tab **Signature Requests** ter-render sebelum tombol
  Approve diklik, lalu memastikan aksi tetap selesai (status sama seperti
  Post-Condition base).
* Daftarkan asset tour ke bundle `web.assets_tests` + dependensi `web_tour`
  di manifest.
* Tambah bagian Work Instruction di `README.rst`.

Tidak ada perubahan pada `models/` — murni dokumentasi + tour, sesuai Ruang
Lingkup issue.

## Kriteria Penerimaan

- [x] Direktori `docs/` ada, validator `ik` 0 ERROR
- [x] IK delta bersection `## Modified Flow` untuk `outgoing_letter`,
      `incoming_letter`, `internal_memo`
- [x] Tiap IK delta menyebut anchor Flow base
- [x] Tiap IK delta memuat blok metadata Module/Extends
- [x] Tiap berkas IK delta punya tepat satu tour pasangan
- [x] Tidak ada berkas `models/` yang berubah

Closes #20