### PR TITLE
[UPD] ssi_letter_work_log

### DIFF
--- a/ssi_letter_work_log/README.rst
+++ b/ssi_letter_work_log/README.rst
@@ -7,6 +7,14 @@ Letter Management - Work Log Integration
 ========================================
 
 
+Work Instruction
+================
+
+* `Approve Outgoing Letter <docs/outgoing_letter/index.html>`_
+* `Create Incoming Letter <docs/incoming_letter/index.html>`_
+* `Create Internal Memo <docs/internal_memo/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_letter_work_log/__manifest__.py
+++ b/ssi_letter_work_log/__manifest__.py
@@ -12,8 +12,11 @@
     "depends": [
         "ssi_letter",
         "ssi_work_log_mixin",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_letter_work_log/docs/incoming_letter/01-create.md
+++ b/ssi_letter_work_log/docs/incoming_letter/01-create.md
@@ -1,0 +1,18 @@
+# Create Incoming Letter
+
+> **Module:** ssi_letter_work_log
+>
+> **Extends:** ssi_letter — model `incoming_letter`, aksi `01-create`
+
+## Modified Flow
+
+- Anchor: on Flow base step 2 (Click the **New** button). This module adds a **Work
+  Log** page to the form (inserted after the last existing tab), showing **Estimation**,
+  **Total**, **Remaining**, and **Excess** hour fields, the **Work Log Analytic
+  Account** field, and the list of work log entries (`hr.work_log`) linked to this
+  document. The page is already rendered on the unsaved create form — no field needs to
+  be filled and no state condition applies.
+- `incoming_letter` never reaches an **On Progress** (`open`) status: once approval
+  completes, the document goes straight to **Done** (see `05-approve`) with no separate
+  working period. **Draft** — the state this Create flow produces — is therefore the
+  state during which this page is typically used.

--- a/ssi_letter_work_log/docs/internal_memo/01-create.md
+++ b/ssi_letter_work_log/docs/internal_memo/01-create.md
@@ -1,0 +1,18 @@
+# Create Internal Memo
+
+> **Module:** ssi_letter_work_log
+>
+> **Extends:** ssi_letter — model `internal_memo`, aksi `01-create`
+
+## Modified Flow
+
+- Anchor: on Flow base step 2 (Click the **New** button). This module adds a **Work
+  Log** page to the form (inserted after the last existing tab), showing **Estimation**,
+  **Total**, **Remaining**, and **Excess** hour fields, the **Work Log Analytic
+  Account** field, and the list of work log entries (`hr.work_log`) linked to this
+  document. The page is already rendered on the unsaved create form — no field needs to
+  be filled and no state condition applies.
+- `internal_memo` never reaches an **On Progress** (`open`) status: once approval
+  completes, the document goes straight to **Done** (see `05-approve`) with no separate
+  working period. **Draft** — the state this Create flow produces — is therefore the
+  state during which this page is typically used.

--- a/ssi_letter_work_log/docs/outgoing_letter/05-approve.md
+++ b/ssi_letter_work_log/docs/outgoing_letter/05-approve.md
@@ -1,0 +1,24 @@
+# Approve Outgoing Letter
+
+> **Module:** ssi_letter_work_log
+>
+> **Extends:** ssi_letter — model `outgoing_letter`, aksi `05-approve`
+
+## Modified Flow
+
+- Anchor: on Flow base step 3 (Click the **Approve** button). This module adds a **Work
+  Log** page to the form (present from record creation onward — see `01-create` —
+  inserted after the last existing tab), showing **Estimation**, **Total**,
+  **Remaining**, and **Excess** hour fields, the **Work Log Analytic Account** field,
+  and the list of work log entries (`hr.work_log`) linked to this document.
+- The page is not gated by document status — it can be opened and filled in any state.
+  However, `outgoing_letter` is the only one of the three models extended by this module
+  that reaches an **On Progress** (`open`) status once approval completes (see base
+  Post-Condition). That On Progress period is the natural point in this document's
+  lifecycle where staff record the hours actually spent working on the letter, before it
+  is marked **Done** (see `09-finish`).
+
+## Additional Post-Condition
+
+- Once this document reaches **On Progress**, its **Work Log** page keeps accepting new
+  entries for as long as the record is in that state.

--- a/ssi_letter_work_log/static/tests/tours/incoming_letter_tour.js
+++ b/ssi_letter_work_log/static/tests/tours/incoming_letter_tour.js
@@ -1,0 +1,82 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_work_log.incoming_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/incoming_letter/01-create.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> New) is taken from the base IK
+    // ssi_letter/docs/incoming_letter/01-create.md Flow steps 1-2 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §1 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion
+    // comes from this module's own IK: the Work Log page is already
+    // rendered on the unsaved create form (no field needs to be filled,
+    // no state condition applies). The tour stops there; it does not
+    // fill or save (delta-only, matching patterns.md §O).
+    tour.register(
+        "ssi_letter_work_log_incoming_letter_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Incoming Letters menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Incoming Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.incoming_letter_menu"]',
+            },
+            {
+                content: "Incoming Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Incoming Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Click the New button. (14.0: "Create")
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Delta assertion — the Work Log page this module adds is
+            // visible on the create form. The tour stops here
+            // (delta-only).
+            {
+                content: "Work Log tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+            },
+            {
+                // Anchored to the field label, not the float widget
+                // itself -- a label always carries text regardless of
+                // the field's value (odoo-development-ui-test skill,
+                // patterns.md §O).
+                content: "Work Log page shows the Estimation field",
+                trigger:
+                    ".o_form_view.o_form_editable .o_form_label:contains(Estimation)",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_work_log/static/tests/tours/internal_memo_tour.js
+++ b/ssi_letter_work_log/static/tests/tours/internal_memo_tour.js
@@ -1,0 +1,82 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_work_log.internal_memo_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/internal_memo/01-create.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> New) is taken from the base IK
+    // ssi_letter/docs/internal_memo/01-create.md Flow steps 1-2 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §1 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion
+    // comes from this module's own IK: the Work Log page is already
+    // rendered on the unsaved create form (no field needs to be filled,
+    // no state condition applies). The tour stops there; it does not
+    // fill or save (delta-only, matching patterns.md §O).
+    tour.register(
+        "ssi_letter_work_log_internal_memo_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Internal Memos menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Internal Memos menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.internal_memo_menu"]',
+            },
+            {
+                content: "Internal Memo list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Internal Memo)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Click the New button. (14.0: "Create")
+            {
+                content: "Click New",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Delta assertion — the Work Log page this module adds is
+            // visible on the create form. The tour stops here
+            // (delta-only).
+            {
+                content: "Work Log tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+            },
+            {
+                // Anchored to the field label, not the float widget
+                // itself -- a label always carries text regardless of
+                // the field's value (odoo-development-ui-test skill,
+                // patterns.md §O).
+                content: "Work Log page shows the Estimation field",
+                trigger:
+                    ".o_form_view.o_form_editable .o_form_label:contains(Estimation)",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_work_log/static/tests/tours/outgoing_letter_tour.js
+++ b/ssi_letter_work_log/static/tests/tours/outgoing_letter_tour.js
@@ -1,0 +1,124 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_letter_work_log.outgoing_letter_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/outgoing_letter/05-approve.md (E2a delta -- Modified Flow)
+    // Navigation (open menu -> open record -> click Approve -> confirm the
+    // dialog) is retraced from the base IK
+    // ssi_letter/docs/outgoing_letter/05-approve.md Flow steps 1-4 -- see
+    // skill odoo-development-ui-test, scope-and-boundaries.md §3 ("Backing
+    // dua file: tour extension = base IK ∪ delta IK"). The delta assertion,
+    // inserted right before the base's Flow step 3, proves the additional
+    // "Work Log" page is visible on the form -- it has been present since
+    // record creation, but this is the anchor documented in the delta IK.
+    // A second delta assertion after the base action completes proves the
+    // page keeps being reachable once the document reaches On Progress
+    // (Additional Post-Condition).
+    tour.register(
+        "ssi_letter_work_log_outgoing_letter_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // ── Base Flow 1 — Open the Letter > Outgoing Letters menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Letter app",
+                trigger: '.o_app[data-menu-xmlid="ssi_letter.menu_root_letter"]',
+            },
+            {
+                content: "Open the Outgoing Letters menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_letter.outgoing_letter_menu"]',
+            },
+            {
+                content: "Outgoing Letter list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Outgoing Letter)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
+
+            // ── Base Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-WL-OL-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Delta anchor — before clicking Approve (base Flow step 3),
+            // open the Work Log page this module adds and prove it is
+            // rendered.
+            {
+                content: "Open the Work Log tab",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+            },
+            {
+                // Anchored to the field label, not the float widget itself
+                // -- a label always carries text regardless of the
+                // field's value (odoo-development-ui-test skill,
+                // patterns.md §O).
+                content: "Work Log page shows the Estimation field",
+                trigger: ".o_form_label:contains(Estimation)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Base Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // ── Base Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // ── Base Post-Condition — the action still completes: status
+            // jumps straight to On Progress.
+            {
+                content: "Status is On Progress",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // ── Additional Post-Condition — the Work Log page keeps being
+            // reachable now that the document is On Progress, the period
+            // during which staff typically record their hours before
+            // Finish (see docs/outgoing_letter/09-finish.md, base module).
+            {
+                content: "Work Log tab is still reachable while On Progress",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+            },
+            {
+                content: "Work Log page still shows the Estimation field",
+                trigger: ".o_form_label:contains(Estimation)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_letter_work_log/tests/__init__.py
+++ b/ssi_letter_work_log/tests/__init__.py
@@ -3,3 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_letter_work_log  # noqa: F401
+from . import test_ui_incoming_letter  # noqa: F401
+from . import test_ui_internal_memo  # noqa: F401
+from . import test_ui_outgoing_letter  # noqa: F401

--- a/ssi_letter_work_log/tests/test_ui_incoming_letter.py
+++ b/ssi_letter_work_log/tests/test_ui_incoming_letter.py
@@ -1,0 +1,31 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiIncomingLetter(HttpSavepointCase):
+    """Tour test for the create-time Work Log page.
+
+    No fixture data is needed: ``incoming_letter_validator_group``
+    already grants ``base.user_admin`` membership by default (see
+    ``ssi_letter``'s ``security/res_groups/incoming_letter.xml``), so
+    ``admin`` can open the **New** form without any extra setup, and
+    the delta being tested is visible on that unsaved form.
+    """
+
+    def test_create(self):
+        """Run the create tour for ``incoming_letter``.
+
+        IK: docs/incoming_letter/01-create.md (E2a delta -- Modified
+        Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_work_log_incoming_letter_create",
+            login="admin",
+        )

--- a/ssi_letter_work_log/tests/test_ui_internal_memo.py
+++ b/ssi_letter_work_log/tests/test_ui_internal_memo.py
@@ -1,0 +1,31 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiInternalMemo(HttpSavepointCase):
+    """Tour test for the create-time Work Log page.
+
+    No fixture data is needed: ``internal_memo_validator_group``
+    already grants ``base.user_admin`` membership by default (see
+    ``ssi_letter``'s ``security/res_groups/internal_memo.xml``), so
+    ``admin`` can open the **New** form without any extra setup, and
+    the delta being tested is visible on that unsaved form.
+    """
+
+    def test_create(self):
+        """Run the create tour for ``internal_memo``.
+
+        IK: docs/internal_memo/01-create.md (E2a delta -- Modified
+        Flow)
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_work_log_internal_memo_create",
+            login="admin",
+        )

--- a/ssi_letter_work_log/tests/test_ui_outgoing_letter.py
+++ b/ssi_letter_work_log/tests/test_ui_outgoing_letter.py
@@ -1,0 +1,66 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiOutgoingLetter(HttpSavepointCase):
+    """Tour test for the Work Log page on Approve."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create one confirmed ``outgoing_letter`` fixture for the tour.
+
+        ``outgoing_letter_validator_group`` already grants
+        ``base.user_admin`` membership by default (see ``ssi_letter``'s
+        ``security/res_groups/outgoing_letter.xml``), so ``admin`` can
+        both open and approve the fixture without any extra group
+        setup. The record's ``user_id`` is set explicitly to ``admin``
+        — ``cls.env`` runs as SUPERUSER here, and the record rule
+        ``outgoing_letter_internal_user_rule`` would otherwise hide it
+        from the ``admin`` tour session.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        company_partner = cls.env.company.partner_id
+        partner = cls.env["res.partner"].create(
+            {"name": "TOUR WL OL Partner", "is_company": True}
+        )
+        letter_type = cls.env["letter_type"].create(
+            {"name": "TOUR WL OL Type", "code": "/"}
+        )
+        internal_partner = cls.env["res.partner"].create(
+            {
+                "name": "TOUR-WL-OL-APPROVE",
+                "parent_id": company_partner.id,
+                "is_company": False,
+            }
+        )
+        cls.rec_approve = cls.env["outgoing_letter"].create(
+            {
+                "partner_id": partner.id,
+                "internal_partner_id": internal_partner.id,
+                "type_id": letter_type.id,
+                "date": "2026-01-15",
+                "title": "TOUR WL Outgoing Letter Approve",
+                "digital": True,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.rec_approve.with_user(cls.admin).action_confirm()
+        cls.rec_approve.invalidate_cache()
+
+    def test_approve(self):
+        """Run the approve tour for ``outgoing_letter``.
+
+        IK: docs/outgoing_letter/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_letter_work_log_outgoing_letter_approve",
+            login="admin",
+        )

--- a/ssi_letter_work_log/views/assets.xml
+++ b/ssi_letter_work_log/views/assets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_letter_work_log assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_letter_work_log/static/tests/tours/outgoing_letter_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_letter_work_log/static/tests/tours/incoming_letter_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_letter_work_log/static/tests/tours/internal_memo_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary

* Tambah IK delta untuk `outgoing_letter` (05-approve), `incoming_letter` (01-create), dan
  `internal_memo` (01-create) yang mendokumentasikan halaman **Work Log** yang disisipkan
  `mixin.work_object` ke form ketiga dokumen (`_work_log_create_page = True`).
* Tambah tour UI test pasangannya — satu tour per berkas IK delta — beserta registrasi asset
  `web.assets_tests`.
* Perbarui `README.rst` dengan bagian Work Instruction.

Tidak ada perubahan pada `models/` — murni dokumentasi + tour, sesuai Ruang Lingkup issue.

Closes open-synergy/ssi-letter#21

## Test plan

- [x] `verify-module.sh` — 0 ERROR
- [x] `validate-ik.sh` — 0 ERROR, 0 peringatan
- [x] `validate-tour.sh` — 0 ERROR
- [x] `pre-commit-gate.sh` — GATE OK (6/6 validator)
- [ ] CI GitHub hijau